### PR TITLE
Update German channels

### DIFF
--- a/germany.md
+++ b/germany.md
@@ -3,29 +3,17 @@
 <h2>DVB-T</h2>
 
 https://en.wikipedia.org/wiki/Television_in_Germany
+https://wiki.ubuntuusers.de/Internet-TV/Stationen
 
 | #   | Channel        | Link  | Logo |
 |:---:|:--------------:|:-----:|:-----:
-| 1   | ARD Ⓖ         | [>](https://mcdn.daserste.de/daserste/de/master.m3u8) | <img height="20" src="https://i.imgur.com/kRq4CIF.png"/> |
-| 2   | ZDF            | [x]() | <img height="20" src="https://i.imgur.com/JosNLQ0.png"/> |
-| 3   | RTL            | [x]() | <img height="20" src="https://i.imgur.com/ip02mlF.png"/> |
-| 4   | SAT.1          | [x]() | <img height="20" src="https://i.imgur.com/ZE0tFzY.png"/> |
-| 5   | ProSieben      | [x]() | <img height="20" src="https://i.imgur.com/keVX5ZX.png"/> |
-| 6   | VOX            | [x]() | <img height="20" src="https://i.imgur.com/hydrTtY.png"/> |
-| 7   | kabel eins     | [x]() | <img height="20" src="https://i.imgur.com/9sHEfdl.png"/> |
-| 8   | RTL II         | [>](https://stream.y5.hu/stream/stream_rtl2/hls1/stream.m3u8) | <img height="20" src="https://i.imgur.com/WCGjWPQ.png"/> |
-| 9   | 3sat           | [x]() | <img height="20" src="https://i.imgur.com/2r7GK0L.png"/> |
-| 10  | Arte           | [x]() | <img height="20" src="https://i.imgur.com/fojjpeg.png"/> |
-| 11  | One            | [x]() | <img height="20" src="https://i.imgur.com/zu5gaQU.png"/> |
-| 12  | ZDFinfo        | [x]() | <img height="20" src="https://i.imgur.com/0jcN11J.png"/> |
-| 13  | ZDFneo         | [x]() | <img height="20" src="https://i.imgur.com/XMPIWeS.png"/> |
-| 14  | sixx           | [x]() | <img height="20" src="https://i.imgur.com/AXm99rZ.png"/> |
-| 15  | DMAX           | [x]() | <img height="20" src="https://i.imgur.com/parLoo9.png"/> |
-| 16  | TELE 5         | [x]() | <img height="20" src="https://i.imgur.com/frGZYrG.png"/> |
-| 17  | SAT.1 Gold     | [x]() | <img height="20" src="https://i.imgur.com/S6fndVU.png"/> |
-| 18  | ProSieben MAXX | [x]() | <img height="20" src="https://i.imgur.com/4N3Jr0E.png"/> |
-| 19  | NITRO          | [x]() | <img height="20" src="https://i.imgur.com/LmL8AaF.png"/> |
-| 20  | RTLplus Ⓢ     | [>](https://stream.y5.hu/stream/stream_rtlp/stream.m3u8) | <img height="20" src="https://i.imgur.com/Im0b5nm.png"/> |
+| 1   | Das Erste Ⓖ   | [>](https://mcdn.daserste.de/daserste/de/master_3628.m3u8) | <img height="20" src="https://i.imgur.com/kRq4CIF.png"/> |
+| 2   | ZDF Ⓖ         | [>](http://zdf-hls-15.akamaized.net/hls/live/2016498/de/veryhigh/master.m3u8) | <img height="20" src="https://i.imgur.com/JosNLQ0.png"/> |
+| 3   | 3sat Ⓖ        | [>](https://zdf-hls-18.akamaized.net/hls/live/2016501/dach/veryhigh/master.m3u8) | <img height="20" src="https://i.imgur.com/2r7GK0L.png"/> |
+| 4   | ARTE Ⓖ        | [>](https://artelive-lh.akamaihd.net/i/artelive_de@393591/index_1_av-p.m3u8) | <img height="20" src="https://i.imgur.com/fojjpeg.png"/> |
+| 5   | ONE Ⓖ         | [>](https://onelivestream-lh.akamaihd.net/i/one_livestream@568814/index_4_av-p.m3u8) | <img height="20" src="https://i.imgur.com/zu5gaQU.png"/> |
+| 6   | ZDFinfo Ⓖ     | [>](https://zdf-hls-17.akamaized.net/hls/live/2016500/de/veryhigh/master.m3u8) | <img height="20" src="https://i.imgur.com/0jcN11J.png"/> |
+| 7   | ZDFneo Ⓖ      | [>](https://zdf-hls-16.akamaized.net/hls/live/2016499/de/veryhigh/master.m3u8) | <img height="20" src="https://i.imgur.com/XMPIWeS.png"/> |
 
 <h2>Invalid</h2>
 


### PR DESCRIPTION
* Add new links for: ZDF, 3sat, ARTE, ONE, ZDFinfo, ZDFneo
* Remove links for: RTL II and RTLplus, those links are not Germanm, but
Hungarian (.hu); in Germany there are chanels with the same name, but
they are not free
* Remove non-free channels: RTL, SAT.1, ProSieben, VOX, kabel eins,
sixx, DMAX, TELE 5 SAT.1 Gold, ProSieben MAXX, NITRO (those channels are
private channels and according to ubuntuusers.de (see below) are only
accesible through a webbrowser after (free) registration.)
* I've used links in HD quality and added "HD" to the channel names,
because the channels show the "HD" besides their logos as well.
* Changes link for "ARD" = "Das Erste", because the current link seems
to be VERY slow to load, when you switch the channels. The new link
seems to be a little faster.

Used sources:
* https://wiki.ubuntuusers.de/Internet-TV/Stationen
* https://github.com/jnk22/kodinerds-iptv/blob/master/iptv/clean/clean_tv_main.m3u
* https://github.com/jnk22/kodinerds-iptv/blob/master/iptv/clean/clean_tv.m3u

According to the (German) README "Kodinerds IPTV" is a collection of free-to-air
streams for TV and radio stations.