### PR TITLE
Update italy.md

### DIFF
--- a/italy.md
+++ b/italy.md
@@ -45,6 +45,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 55  | Mediaset Extra Ⓢ Ⓖ | [>](https://live3-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(kq)/index.m3u8) | <img height="20" src="https://i.imgur.com/mM8lopo.png"/> |
 | 57  | Rai Sport + Ⓖ | [>](https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=358025) | <img height="20" src="https://i.imgur.com/xsGljsb.png"/> |
 | 59  | Motor Trend    | [>](https://sbshdlu5-lh.akamaihd.net/i/sbshdl_1@810993/master.m3u8) | <img height="20" src="https://i.imgur.com/ipj2H0n.png"/> |
+| 65  | Alma TV        | [>](https://5f11919dca3bd.streamlock.net/AlmaTv/AlmaTv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Y8JiDwN.png"/> |
 | 66  | Italia 2 Ⓢ Ⓖ  | [>](https://live3-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(i2)/index.m3u8) | <img height="20" src="https://i.imgur.com/nq48sjO.png"/> |
 | 67  | VH1            | [>](https://content.uplynk.com/channel/36953f5b6546464590d2fcd954bc89cf.m3u8) | <img height="20" src="https://i.imgur.com/5ONlZGS.png"/> |
 | 69  | Deejay TV Ⓢ    | [>](https://deejay-tv-lh.akamaized.net/i/DeejayTv_1@129866/master.m3u8) | <img height="20" src="https://i.imgur.com/rlaKH6k.png"/> |
@@ -111,5 +112,3 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 44  | Frisbee        | [x](https://sbshdlu1-lh.akamaihd.net/i/sbshdl_21@443313/master.m3u8) | <img height="20" src="https://i.imgur.com/9y1zIAe.png"/> |
 | 56  | HGTV – Home & Garden Tv  | [x](https://sbshdlu5-lh.akamaihd.net/i/sbshdl_7@106896/master.m3u8) | <img height="20" src="https://i.imgur.com/emLNC0U.png"/> |
 | 60  | Sportitalia    | [x]() | <img height="20" src="https://i.imgur.com/hu56Ya5.png"/> |
-| 221 | Alice          | [x](https://dcunilive130-lh.akamaihd.net/i/dclive_1@352796/master.m3u8) | <img height="20" src="https://i.imgur.com/FArUGWt.png"/> |
-| 222 | Marcopolo      | [x](https://dcunilive131-lh.akamaihd.net/i/dclive_1@352774/master.m3u8) | <img height="20" src="https://i.imgur.com/mSo7Cw4.png"/> |


### PR DESCRIPTION
CHANGELOG: 
- Removed "Alice" and "Marcopolo" from "Invalid" section. These channels have been permanently closed on tv and via streaming.
- Added "Alma TV" on "DVB-T" section.