### PR TITLE
Add SBT to brazil.md

### DIFF
--- a/brazil.md
+++ b/brazil.md
@@ -5,3 +5,4 @@
 | 1   | ALL Sports Brasil | [>](https://5cf4a2c2512a2.streamlock.net/dgrau/dgrau/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/wULpnYR.png"/> |
 | 2   | COM Brasil | [>](https://596639ebdd89b.streamlock.net/8032/8032/index.m3u8) | <img height="20" src="https://i.imgur.com/c8ztQnF.png"/> |
 | 3   | CNN Brasil Ⓢ   | [>](https://streaming.cnnbrasil.com.br/cnndigital_main.m3u8) | <img height="20" src="https://i.imgur.com/FYdDmO1.png"/> |
+| 7   | SBT Ⓢ    | [>](http://wz4.dnip.com.br/bemtv/bemtv.sdp/playlist.m3u8) | <img height="20" src="https://logodownload.org/wp-content/uploads/2013/12/sbt-logo.png"/> |

--- a/brazil.md
+++ b/brazil.md
@@ -1,0 +1,6 @@
+<h1>Brazil</h1>
+
+| #   | Channel     | Link  | Logo |
+|:---:|:-----------:|:-----:|:-----:
+| 1   | ALL Sports Brasil | [>](https://5cf4a2c2512a2.streamlock.net/dgrau/dgrau/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/wULpnYR.png"/> |
+| 2   | COM Brasil | [>](https://596639ebdd89b.streamlock.net/8032/8032/index.m3u8) | <img height="20" src="https://i.imgur.com/c8ztQnF.png"/> |

--- a/brazil.md
+++ b/brazil.md
@@ -5,4 +5,4 @@
 | 1   | ALL Sports Brasil | [>](https://5cf4a2c2512a2.streamlock.net/dgrau/dgrau/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/wULpnYR.png"/> |
 | 2   | COM Brasil | [>](https://596639ebdd89b.streamlock.net/8032/8032/index.m3u8) | <img height="20" src="https://i.imgur.com/c8ztQnF.png"/> |
 | 3   | CNN Brasil Ⓢ   | [>](https://streaming.cnnbrasil.com.br/cnndigital_main.m3u8) | <img height="20" src="https://i.imgur.com/FYdDmO1.png"/> |
-| 7   | SBT Ⓢ    | [>](http://wz4.dnip.com.br/bemtv/bemtv.sdp/playlist.m3u8) | <img height="20" src="https://logodownload.org/wp-content/uploads/2013/12/sbt-logo.png"/> |
+| 4   | SBT Ⓢ    | [>](http://wz4.dnip.com.br/bemtv/bemtv.sdp/playlist.m3u8) | <img height="20" src="https://logodownload.org/wp-content/uploads/2013/12/sbt-logo.png"/> |


### PR DESCRIPTION
Adds a brazilian channel which is available on a free-to-air signal on satellite receivers and also through streaming media in their mobile application. You can read more on the links below:
https://www.sbt.com.br/ (Portuguese)
https://en.wikipedia.org/wiki/Sistema_Brasileiro_de_Televis%C3%A3o (English)