### PR TITLE
Add czech & slovak channels

### DIFF
--- a/czech_republic.md
+++ b/czech_republic.md
@@ -1,0 +1,8 @@
+<h1>Czech Republic</h1>
+
+| #   | Channel        | Link  | Logo |
+|:---:|:--------------:|:-----:|:----:|
+| 1   | JOJ Family    | [>](https://nn.geo.joj.sk/live/hls/family-540.m3u8) | <img height="20" src="https://i.imgur.com/IZHIAAj.png"/> |
+| 2   | Šlágr    | [>](https://stream-6.mazana.tv/slagr.m3u) | <img height="20" src="https://i.imgur.com/0bTyHve.png"/> |
+| 3   | Šlágr 2    | [>](https://stream-33.mazana.tv/slagr2.m3u) | <img height="20" src="https://i.imgur.com/2rcy4Wo.png"/> |
+| 4   | Šlágr Premium    | [>](https://arenasportslovakia.ddns.net/hls/slager.m3u8) | <img height="20" src="https://i.imgur.com/Lp0IqDx.png"/> |

--- a/slovakia.md
+++ b/slovakia.md
@@ -1,0 +1,8 @@
+<h1>Slovakia</h1>
+
+| #   | Channel        | Link  | Logo |
+|:---:|:--------------:|:-----:|:----:|
+| 1   | JOJ    | [>](https://nn.geo.joj.sk/live/hls/joj-720.m3u8) | <img height="20" src="https://i.imgur.com/5BAWD0z.png"/> |
+| 2   | JOJ Plus    | [>](https://nn.geo.joj.sk/live/hls/jojplus-540.m3u8) | <img height="20" src="https://i.imgur.com/L280xHZ.png"/> |
+| 3   | WAU    | [>](https://nn.geo.joj.sk/live/hls/wau-540.m3u8) | <img height="20" src="https://i.imgur.com/3M46moH.png"/> |
+| 4   | Senzi    | [>](http://lb.streaming.sk/senzi/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/W82dwzf.png"/> |

--- a/slovakia.md
+++ b/slovakia.md
@@ -3,6 +3,6 @@
 | #   | Channel        | Link  | Logo |
 |:---:|:--------------:|:-----:|:----:|
 | 1   | JOJ    | [>](https://nn.geo.joj.sk/live/hls/joj-720.m3u8) | <img height="20" src="https://i.imgur.com/5BAWD0z.png"/> |
-| 2   | JOJ Plus    | [>](https://nn.geo.joj.sk/live/hls/jojplus-540.m3u8) | <img height="20" src="https://i.imgur.com/L280xHZ.png"/> |
+| 2   | JOJ Plus    | [>](https://nn.geo.joj.sk/live/hls/jojplus-540.m3u8) | <img height="20" src="https://i.imgur.com/0ubDv0w.png"/> |
 | 3   | WAU    | [>](https://nn.geo.joj.sk/live/hls/wau-540.m3u8) | <img height="20" src="https://i.imgur.com/3M46moH.png"/> |
 | 4   | Senzi    | [>](http://lb.streaming.sk/senzi/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/W82dwzf.png"/> |


### PR DESCRIPTION
All of these have live broadcasts on the TV's respective websites.
(Note: Šlágr Premium might sound paid, but it has an official free broadcast on their website too)

https://live.joj.sk/
http://senzi.sk/senzi_televizia_vysielamie_live_stream.html
https://jojfamily.blesk.cz/live (only the website is region-locked, not the stream itself)
https://www.slagrtv.cz/