### PR TITLE
Update italy.md

### DIFF
--- a/italy.md
+++ b/italy.md
@@ -1,6 +1,6 @@
 <h1>Italy</h1>
 
-<h2>DVB-T</h2>
+<h2>National</h2>
 
 https://en.wikipedia.org/wiki/Television_in_Italy#Digital_terrestrial_television
 https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
@@ -56,8 +56,6 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 67  | VH1            | [>](https://content.uplynk.com/channel/36953f5b6546464590d2fcd954bc89cf.m3u8) | <img height="20" src="https://i.imgur.com/5ONlZGS.png"/> |
 | 69  | Deejay TV Ⓢ    | [>](https://deejay-tv-lh.akamaized.net/i/DeejayTv_1@129866/master.m3u8) | <img height="20" src="https://i.imgur.com/rlaKH6k.png"/> |
 | 70  | RadioItaliaTV Ⓢ | [>](https://radioitaliatv-lh.akamaihd.net/i/radioitaliatv_1@329645/master.m3u8) | <img height="20" src="https://i.imgur.com/4VCEJuJ.png"/> |
-| 77  | 7 Gold         | [>](http://stream2.xdevel.com/video0s86-21/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wjZT8De.png"/> |
-| 86  | Supersix       | [>](https://5db313b643fd8.streamlock.net/SUPERSIXLombardia/SUPERSIXLombardia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kHSuyub.png"/> |
 | 146 | Rai Scuola Ⓖ  | [>](https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=747011) | <img height="20" src="https://i.imgur.com/tmtJW6s.png"/> |
 | 157 | Radio 105 TV Ⓢ Ⓖ | [>](https://live3-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(EC)/index.m3u8) | <img height="20" src="https://i.imgur.com/3NiLKvj.png"/> |
 | 158 | Radio KISS KISS TV | [>](https://59253971be783.streamlock.net/KissKissTV/KissKissTV.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qxu8Fkh.png"/> |
@@ -67,6 +65,296 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 265 | RDS Social TV Ⓢ | [>](https://stream.rdstv.radio/out/v1/ec85f72b87f04555aa41d616d5be41dc/index.m3u8) | <img height="20" src="https://i.imgur.com/TVuu0DH.png"/> |
 | 266 | Radio ZETA Ⓢ   | [>](https://rtl-video3-stream.thron.com/live-video/video3/ngrp:video3/playlist.m3u8) | <img height="20" src="https://i.imgur.com/0MgCm1n.png"/> |
 | 772 | Radio Montecarlo TV Ⓢ Ⓖ | [>](https://live3-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(BB)/index.m3u8) | <img height="20" src="https://i.imgur.com/3TMMXmS.png"/> |
+
+<h2>Regional</h2>
+
+| #   | Channel        | Link  | Logo |
+|:---:|:--------------:|:-----:|:-----:
+| 0   | 111 Tv | [>](https://5db313b643fd8.streamlock.net/111TV/111TV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4jY8yAI.png"/> |
+| 0   | 12 Tv Parma | [>](https://meridelive01-lh.akamaihd.net/i/tvparma_1@356964/master.m3u8) | <img height="20" src="https://i.imgur.com/xnUgx6b.png"/> |
+| 0   | 696 Tv | [>](https://meridelive-lh.akamaihd.net/i/ottop_1@118465/index_1_av-p.m3u8?sd=10&rebase=on) | <img height="20" src="https://i.imgur.com/i6PJJDU.png"/> |
+| 0   | 8 Video Calabria | [>](http://wms.shared.streamshow.it:80/videocalabria/videocalabria/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9bVuiaQ.png"/> |
+| 0   | AB Channel  | [>](https://tsw.streamingwebtv24.it:1936/abchanneltv/abchanneltv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ze2xvoY.png"/> |
+| 0   | Abc Tv | [>](https://streamlive.arcapuglia.it:8080/live/abctv/index.m3u8) | <img height="20" src="https://i.imgur.com/nVmIeTD.png"/> |
+| 0   | Alpa 1 | [>](http://live.streamcaster.net:1935/alpauno/alpauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4QKFtUa.png"/> |
+| 0   | Alto Adige Tv | [>](https://5f204aff97bee.streamlock.net/AltoAdigeTV/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/S2sCFQi.png"/> |
+| 0   | Antenna 2 Bergamo | [>](https://58f12ffd2447a.streamlock.net/Antenna2/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NfvHIAw.png"/> |
+| 0   | Antenna 3 Massa | [>](http://163.172.88.73:1935/antenna3massa/a3/playlist.m3u8) | <img height="20" src="https://i.imgur.com/79dWgVB.png"/> |
+| 0   | Antenna 3 Veneto Nord Est | [>](https://59d8c0cee6f3d.streamlock.net/antennatreveneto/antennatreveneto.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NiVHLwp.png"/> |
+| 0   | Antenna Sud 13 | [>](https://streamlive13.arcapuglia.it:8080/live/antennasud/index.m3u8) | <img height="20" src="https://i.imgur.com/VCn0g3a.png"/> |
+| 0   | Antenna Sud 174 | [>](https://streamlivesud.arcapuglia.it:8080/live/eventi/index.m3u8) | <img height="20" src="https://i.imgur.com/02dXr31.png"/> |
+| 0   | Antenna Sud 299 | [>](https://streamlivesud.arcapuglia.it:8080/live/cult/index.m3u8) | <img height="20" src="https://i.imgur.com/XuIXCKg.png"/> |
+| 0   | Antenna Sud 85 | [>](https://streamlive85.arcapuglia.it:8080/live/canale85/index.m3u8) | <img height="20" src="https://i.imgur.com/0JM7Jw0.png"/> |
+| 0   | Antenna Sud 90 | [>](https://streamlivesud.arcapuglia.it:8080/live/teleonda/index.m3u8) | <img height="20" src="https://i.imgur.com/jsGagGp.png"/> |
+| 0   | Apulia Web Tv | [>](https://cp1.server89.com:19360/apuliawebtv/apuliawebtv.m3u8) | <img height="20" src="https://i.imgur.com/AnU4g2J.png"/> |
+| 0   | Aurora Arte | [>](https://59d7d6f47d7fc.streamlock.net/auroraarte/auroraarte/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/BoLZ5wG.png"/> |
+| 0   | Azzurra Tv Vco | [>](http://sb.top-ix.org:1935/avtvlive/streaming/chunklist_w1605488247.m3u8) | <img height="20" src="https://i.imgur.com/mSWw8uW.png"/> |
+| 0   | Basilicata 1 Tv | [>](http://77.68.40.210:8888/hls/basilicata1.m3u8) | <img height="20" src="https://i.imgur.com/VS6CQ88.png"/> |
+| 0   | Bergamo Tv | [>](http://api.new.livestream.com/accounts/245066/events/3063596/live.m3u8) | <img height="20" src="https://i.imgur.com/1doR6Vl.png"/> |
+| 0   | Byoblu Tv | [>](https://player-api.new.livestream.com/accounts/29084624/events/9394322/broadcasts/223051863.secure.m3u8) | <img height="20" src="https://i.imgur.com/KldC2gI.png"/> |
+| 0   | Cafe Tv 24 | [>](http://srv3.meway.tv:1957/cafe/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KbcbxFw.png"/> |
+| 0   | Calabria Uno TV  | [>](https://5f22d76e220e1.streamlock.net/calabriaunotv/calabriaunotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2TK1GQ5.png"/> |
+| 0   | Calabria tv | [>](https://5db313b643fd8.streamlock.net:443/CalabriaTv2/CalabriaTv2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qWirucd.png"/> |
+| 0   | Canale 10 | [>](http://37.187.142.147:1935/ch10live/high.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KuQcjYV.png"/> |
+| 0   | Canale 12 Sassari | [>](http://wifitv.tv/media/live/1001/video_850000.m3u8) | <img height="20" src="https://i.imgur.com/u6P2lTY.jpg"/> |
+| 0   | Canale 16 | [>](https://5f11919dca3bd.streamlock.net/Canale16/Canale16/playlist.m3u) | <img height="20" src="https://i.imgur.com/SPfgKHk.png"/> |
+| 0   | Canale 18 | [>](https://5f11919dca3bd.streamlock.net/Canale18/Canale18/playlist.m3u8) | <img height="20" src="https://i.imgur.com/PZBX4iy.png"/> |
+| 0   | Canale 2 | [>](https://59d7d6f47d7fc.streamlock.net/canale2/canale2/chunklist_w811855890.m3u8) | <img height="20" src="https://i.imgur.com/ETqDkS1.png"/> |
+| 0   | Canale 21 Campania | [>](https://stream.mariatvcdn.com/canaleventuno/f5d2060b3682e0dfffd5b2f18e935ad3.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KVh8cOR.png"/> |
+| 0   | Canale 21 Lazio | [>](https://stream.mariatvcdn.com/canaleventunodue/61d14e72c90980498c9d7cee64fde847.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KVh8cOR.png"/> |
+| 0   | Canale 58 | [>](https://dotfvxkfj90ca.cloudfront.net/live/canale58_aac/master.m3u8) | <img height="20" src="https://i.imgur.com/RlFc74C.png"/> |
+| 0   | Canale 7 | [>](http://wms.shared.streamshow.it:80/canale7/canale7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9cuOLCn.png"/> |
+| 0   | Canale 74 Sicilia | [>](http://stream.ets-sistemi.it:1935/live.canale74/canale74tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/18JIVgu.png"/> |
+| 0   | Canale 8 | [>](https://59d8c0cee6f3d.streamlock.net/canale8/canale8/chunklist_w592700549.m3u8) | <img height="20" src="https://i.imgur.com/ElAS2WC.png"/> |
+| 0   | Canale Italia 83 | [>](http://ovp-live.akamaized.net/ac024_live/video1/chunklist.m3u8?accessToken=51c3544ac33a24b012ba69bf6349db78) | <img height="20" src="https://i.imgur.com/ZaenpJA.jpg"/> |
+| 0   | Canale Uno Tivù | [>](https://eu1.servers10.com:8081/8096/index.m3u8) | <img height="20" src="https://i.imgur.com/hfqNw92.png"/> |
+| 0   | Carina Tv | [>](http://wms.shared.streamshow.it/carinatv/mp4:carinatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FMGcm6I.jpg"/> |
+| 0   | Casa del Sole Tv | [>](https://eu1.servers10.com:8081/8040/index.m3u8) | <img height="20" src="https://i.imgur.com/qPdGelu.png"/> |
+| 0   | Castrovillari Tv | [>](rtmp://msh0062.stream.seeweb.it:1935/live/stream00.sdp) | <img height="20" src="https://i.imgur.com/V0kjYNG.png"/> |
+| 0   | Cilento Channel | [>](https://streaming.dimind.it/live/cilentocnn/index.m3u8) | <img height="20" src="https://i.imgur.com/4k9Su8j.png"/> |
+| 0   | Cremona 1 | [>](https://59d8c0cee6f3d.streamlock.net/cremona1/cremona1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a5d0F01.jpg"/> |
+| 0   | Di.Tv 90 | [>](http://163.172.88.73:1935/di_tv_90/live/chunklist_w707472623.m3u8) | <img height="20" src="https://i.imgur.com/ul0o7zv.png"/> |
+| 0   | Digital Tv7 Benevento | [>](http://streaming.senecadot.com/live/flv:tv7.sdp/chunklist_w132253248.m3u8) | <img height="20" src="https://i.imgur.com/NaQkklP.png"/> |
+| 0   | E'live Brescia Tv | [>](https://59d7d6f47d7fc.streamlock.net/elivebresciatv/elivebresciatv/chunklist_w1234149773.m3u8) | <img height="20" src="https://i.imgur.com/bZ3B7pi.png"/> |
+| 0   | Easy Tv | [>](https://streamlive.arcapuglia.it:8080/live/canale190/index.m3u8) | <img height="20" src="https://i.imgur.com/LKrVuRR.jpg"/> |
+| 0   | Entella Tv | [>](https://5f22d76e220e1.streamlock.net:443/EntellaTV/EntellaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1VPXKrW.png"/> |
+| 0   | Espansione Tv | [>](https://srvx1.selftv.video/espansione/smil:live.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mm9HKpD.png"/> |
+| 0   | Esperia Tv | [>](http://wms.shared.streamshow.it/esperiatv/esperiatv/chunklist_w1096393748.m3u8) | <img height="20" src="https://patbuweb.com/tivustream/chanlogoz/ita/esperiatv.png"/> |
+| 0   | Etna Espresso Channel | [>](https://5db313b643fd8.streamlock.net/Etnachannelponte/Etnachannelponte/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hMUxytZ.png"/> |
+| 0   | Etv Marche | [>](https://live.ipstream.it/etvmarche/etvmarche.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4UO7q69.png"/> |
+| 0   | Etv Rete7 | [>](https://live.ipstream.it/etv/etv.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gwj65qg.jpg"/> |
+| 0   | Euro Tv | [>](https://5f22d76e220e1.streamlock.net/eurotv/eurotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HCl5Zbu.png"/> |
+| 0   | FM Tv Marche | [>](https://cloudtv.azotosolutions.com:9553/media/media/playlist.m3u8) | <img height="20" src="https://i.imgur.com/yY01NhL.jpg"/> |
+| 0   | Fano Tv (Canale17) | [>](https://5cbd3bc28341f.streamlock.net:444/fanotv_live/_definst_/43DA-3923-9C72-4E9F/chunklist_w1207024846.m3u8) | <img height="20" src="https://i.imgur.com/39oS1s4.jpg"/> |
+| 0   | GRP Televisione | [>](https://5cbd3bc28341f.streamlock.net:444/grp/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1zNPpVE.png"/> |
+| 0   | Giornale Radio Tv | [>](https://5db313b643fd8.streamlock.net:443/GiornaleRadioTelevision/GiornaleRadioTelevision/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TMtvCLL.jpg"/> |
+| 0   | Gold 78 HD  | [>](http://stream2.xdevel.com/video1s86-22/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/2UHu1ye.png"/> |
+| 0   | Gold Tv  | [>](http://151.0.207.99:1935/GoldTV/GOLD_17/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3rVi4kD.png"/> |
+| 0   | HUB Tv | [>](https://5c483b9d1019c.streamlock.net/8004/8004/playlist.m3u8) | <img height="20" src="https://i.imgur.com/46GTBEW.png"/> |
+| 0   | Icaro Tv Rimini | [>](https://59d7d6f47d7fc.streamlock.net/icarotv/icarotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z05VSSN.png"/> |
+| 0   | Idea Plus | [>](https://eu1.servers10.com:8081/8044/index.m3u8) | <img height="20" src="https://i.imgur.com/2edmxYF.png"/> |
+| 0   | Italia 2 | [>](https://59d7d6f47d7fc.streamlock.net/italia2/italia2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ISbxfY0.png"/> |
+| 0   | Italia 7 | [>](http://151.0.207.99:1935/italia7/italia7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/YBXkY4w.png"/> |
+| 0   | Iunior Tv | [>](https://5f22d76e220e1.streamlock.net/iuniortv/iuniortv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9jeNlLE.png"/> |
+| 0   | L'Altro Corriere Tv  | [>](https://stream.ets-sistemi.it/live.laltrocorrieretv/laltrocorrieretv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dgj79J3.png"/> |
+| 0   | La Tua Tv | [>](https://wms2.zivoli.it/latuatv/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Nc3I0cS.png"/> |
+| 0   | La3 Marsala | [>](https://tsw.streamingwebtv24.it:1936/eslife1/eslife1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/XlxpfEx.png"/> |
+| 0   | LaC News 24 | [>](https://cdn.mainstreaming.tv/live/100532/HVvPMzy/playlist.m3u8?rnd=861954) | <img height="20" src="https://i.imgur.com/02vCECa.png"/> |
+| 0   | LaC Tv Calabria | [>](http://streamcdnb9-f5842579ff984c1c98d63b8d789673eb.msvdn.net/live/100197/SOrBDPy/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2Ef6crS.png"/> |
+| 0   | Lab Tv | [>](http://live.sloode.com:1935/labtv_live/labtv/chunklist_w2038941170.m3u8) | <img height="20" src="https://i.imgur.com/OpRS6Fl.png"/> |
+| 0   | Lazio Tv | [>](http://151.0.207.99:1935/live/LAZIOTV12/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6gbWHvP.jpg"/> |
+| 0   | Le Cronache Lucane Tv | [>](http://stucazz.com:8888/hls/cronache.m3u8) | <img height="20" src="https://i.imgur.com/EBY3IZL.jpg"/> |
+| 0   | Lira Tv | [>](https://5e06222f4d978.streamlock.net/liratv/liratv1500/chunklist_w409119112.m3u8) | <img height="20" src="https://i.imgur.com/S0ReVEo.png"/> |
+| 0   | Lombardia Tv | [>](https://5db313b643fd8.streamlock.net/LOMBARDIATV/LOMBARDIATV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/aksVy9f.jpg"/> |
+| 0   | Love in Venice | [>](http://59d7d6f47d7fc.streamlock.net/loveinvenice/loveinvenice/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lLBzzce.png"/> |
+| 0   | Lucania Tv | [>](http://wms.shared.streamshow.it:80/lucaniatv/lucaniatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wuUNVR5.png"/> |
+| 0   | Made in BO | [>](https://srvx1.selftv.video/dmchannel/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WFnrMS0.png"/> |
+| 0   | Media Tv | [>](http://live.sloode.com:1935/mediatv/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WFiRWO9.png"/> |
+| 0   | Mediterranea Tv | [>](https://59bb40cf810aa.streamlock.net:4443/streamingvincente/streamingvincente/chunklist_w1462632196.m3u8) | <img height="20" src="https://i.imgur.com/GUTOqRt.png"/> |
+| 0   | Medjugorje Italia Tv | [>](https://5f22d76e220e1.streamlock.net/medjugorjeitaliatv/medjugorjeitaliatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hkZScXf.png"/> |
+| 0   | Medjugorje Tv Puglia  | [>](https://streamlive.arcapuglia.it:8080/live/medjugorietv/index.m3u8) | <img height="20" src="https://i.imgur.com/IWBeddh.png"/> |
+| 0   | Minformo Tv | [>](https://5db313b643fd8.streamlock.net:443/MinformoTV/MinformoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/VJNtnZM.jpg"/> |
+| 0   | NSL            | [>](https://streannunsec-lh.akamaihd.net/i/tv_1@868496/master.m3u8) | <img height="20" src="https://i.imgur.com/5W6vRaf.png"/> |
+| 0   | NTI Canale 271 | [>](https://www.ntimedia.it/video/S0/S0_master.m3u8) | <img height="20" src="https://i.imgur.com/zlmcUe0.jpg"/> |
+| 0   | Napoli Nova Tv | [>](https://stream1.aswifi.it/napolinova/live/index.m3u8) | <img height="20" src="https://i.imgur.com/P5Boz0e.jpg"/> |
+| 0   | New Signal Tv Genova | [>](https://5f22d76e220e1.streamlock.net/NewSignalTV/NewSignalTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/5uGTCJn.png"/> |
+| 0   | Nuova TV Nazionale | [>](https://stream4.xdevel.com/video0s975955-782/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QWlRuXg.png"/> |
+| 0   | Nuova Tv 1  | [>](https://nuovatv.net:8443/tv/stream.m3u8) | <img height="20" src="https://i.imgur.com/1yqTZhR.png"/> |
+| 0   | Nuova Tv 2 | [>](https://nuovatv.net:8443/tv2/stream.m3u8) | <img height="20" src="https://i.imgur.com/0vauyV3.png"/> |
+| 0   | Ofanto Tv | [>](http://media.az-mediaserver.com:1935/7446/7446/chunklist_w454796868.m3u8) | <img height="20" src="https://i.imgur.com/UCgATWn.png"/> |
+| 0   | Onda Novara Tv | [>](https://585b674743bbb.streamlock.net/9006/9006/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Qoh9CFy.png"/> |
+| 0   | Onda Tv Sicilia | [>](https://5926fc9c7c5b2.streamlock.net/9040/9040/playlist.m3u8) | <img height="20" src="https://i.imgur.com/0c5Y6lr.png"/> |
+| 0   | Onda Web Radio | [>](http://178.33.224.197:1935/ondaradioweb/ondaradioweb/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3hTvrC8.jpg"/> |
+| 0   | One Tv E.R. | [>](https://5db313b643fd8.streamlock.net:443/OneTvEmilia/OneTvEmilia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/iAg0Kjl.png"/> |
+| 0   | Ora Tv | [>](https://5db313b643fd8.streamlock.net/OraTv/OraTv/chunklist_w1858583108.m3u8) | <img height="20" src="https://i.imgur.com/clWVrvE.png"/> |
+| 0   | Orler Tv | [>](https://w1.mediastreaming.it/orlertv/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dBkxD8e.png"/> |
+| 0   | Padre Pio Tv | [>](https://600f07e114306.streamlock.net/PadrePioTV/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/7ajxEPH.png"/> |
+| 0   | Paradise Tv | [>](https://tsw.streamingwebtv24.it:1936/paradisetv/paradisetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/okIBfIb.jpg"/> |
+| 0   | Partenope Tv | [>](https://streamlive.arcapuglia.it:8080/live/partenopetv/index.m3u8) | <img height="20" src="https://i.imgur.com/FtuWkj1.png"/> |
+| 0   | Passione Lotto Tv | [>](http://185.63.52.103:8080/hls/passionelotto/1_2/index.m3u8) | <img height="20" src="https://i.imgur.com/E2JBphv.jpg"/> |
+| 0   | Pop Tv | [>](https://59d7d6f47d7fc.streamlock.net/poptv/poptv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TeolCu9.png"/> |
+| 0   | PrimAntenna TV | [>](https://585b674743bbb.streamlock.net:443/9062/9062/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gSklP3y.png"/> |
+| 0   | Prima Napoli Tv | [>](https://stream1.aswifi.it/primatvnapoli/live/index.m3u8) | <img height="20" src="https://i.imgur.com/yPuQeEy.jpg"/> |
+| 0   | Prima Tivvù | [>](https://streamtechglobal.akamaized.net/hls/live/2024751/primativvu/Group02/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oUGS2Nt.png"/> |
+| 0   | Prima Tv Sicilia | [>](https://5db313b643fd8.streamlock.net/PrimaTV/PrimaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ivkFRZ1.jpg"/> |
+| 0   | Prima Tv | [>](http://flash2.streaming.xdevel.com/primatv/primatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/br45JER.png"/> |
+| 0   | Primantenna Torino | [>](https://585b674743bbb.streamlock.net/9062/9062/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sqEcPFs.gif"/> |
+| 0   | Primocanale | [>](https://msh0203.stream.seeweb.it/live/flv:stream2.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/xWF1A1U.png"/> |
+| 0   | Promovideo Tv | [>](https://media2021.rtvweb.com/promovideo_web/promovideo/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MwK9HVG.png"/> |
+| 0   | Quarto Canale Flegreo | [>](http://live.mariatvcdn.com/dialogos/171e41deedf405f10c7dd6311387fb43.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/8RKY3Du.png"/> |
+| 0   | R+Tv Abruzzo | [>](https://54627d4fc5996.streamlock.net/rnews/rnews/playlist.m3u8) | <img height="20" src="https://i.imgur.com/jKVvT3K.jpg"/> |
+| 0   | R.T.C. Quarta Rete | [>](https://msh0232.stream.seeweb.it/live/stream00.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rFGA6qL.png"/> |
+| 0   | R.T.C. Telecalabria | [>](https://w1.mediastreaming.it/calabriachannel/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/tTYLcuh.jpg"/> |
+| 0   | R.T.I. Calabria | [>](https://stream.ets-sistemi.it/live.rti/rti-calabria/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hVzEvmo.jpg"/> |
+| 0   | RDE Tv | [>](https://visual.shoutca.st:1936/saiuz2/rde/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NiwPlrr.png"/> |
+| 0   | Radio Colonna Tv | [>](https://5f22d76e220e1.streamlock.net/rctv/rctv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/EcQvDfq.png"/> |
+| 0   | Radio Italia Cina Tv | [>](https://585b674743bbb.streamlock.net/9054/9054/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QGkyrO3.png"/> |
+| 0   | Radio Monte Kronio Tv (R.M.K.) | [>](http://vod1.kronopress.com:1935/tmk_live/5123-CA5C-9EBE-428A/chunklist_w758377964.m3u8) | <img height="20" src="https://i.imgur.com/t0I2Shi.jpg"/> |
+| 0   | Reggio Tv | [>](https://59d7d6f47d7fc.streamlock.net/reggiotv/reggiotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/merrg2C.png"/> |
+| 0   | Rete 55 | [>](https://stream.internet.one/Rete55_Live/index.m3u8) | <img height="20" src="https://i.imgur.com/EsZn2cj.png"/> |
+| 0   | Rete 7 Tv | [>](https://stream.ets-sistemi.it/live.rete7/rete7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lUTxfoh.png"/> |
+| 0   | Rete 8 Vga | [>](https://604e46ac2bdee.streamlock.net:1936/rete8_1/rete8_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3wF2AJX.jpg"/> |
+| 0   | Rete 8 | [>](https://dcunilive263-lh.akamaihd.net/i/dclive_1@348290/index_150_av-p.m3u8?sd=10&rebase=on) | <img height="20" src="https://i.imgur.com/5WLYqLx.jpg"/> |
+| 0   | Rete Biella | [>](https://sb.top-ix.org/retebiella/streaming/playlist.m3u8) | <img height="20" src="https://i.imgur.com/e2ryHx7.png"/> |
+| 0   | Rete Chiara | [>](https://cp1.server89.com:19360/mediamasterpress/mediamasterpress.m3u8) | <img height="20" src="https://i.imgur.com/viL8ZrS.png"/> |
+| 0   | Rete Mia  | [>](https://5db313b643fd8.streamlock.net/Retemia/Retemia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kCJ621Q.png"/> |
+| 0   | Rete Oro Tv | [>](https://5926fc9c7c5b2.streamlock.net/9094/9094/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rkN64Gb.png"/> |
+| 0   | Rete Sole (Lazio) | [>](http://5c389faa13be3.streamlock.net:1935/8056/8056/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ajaa5pk.png"/> |
+| 0   | Rete Sole (Umbria) | [>](http://5c389faa13be3.streamlock.net:1935/8058/8058/chunklist_w696604988.m3u8) | <img height="20" src="https://i.imgur.com/u0ezKgE.png"/> |
+| 0   | Rete Tv Italia | [>](https://57068da1deb21.streamlock.net/retetvitalia/retetvitalia/chunklist_w992954157.m3u8) | <img height="20" src="https://i.imgur.com/lXGWoV9.png"/> |
+| 0   | Rete Veneta | [>](http://wms.shared.streamshow.it/reteveneta/reteveneta/chunklist_w1047580983.m3u8) | <img height="20" src="https://i.imgur.com/cInhQFp.png"/> |
+| 0   | Rossini Tv | [>](https://5cbd3bc28341f.streamlock.net:444/rossinitv_live/944A-63A6-9EB8-4492/playlist.m3u8) | <img height="20" src="https://i.imgur.com/K0Em0nx.jpg"/> |
+| 0   | Rtc Targato Napoli | [>](https://eu1.servers10.com:8081/8014/index.m3u8) | <img height="20" src="https://i.imgur.com/Jsep7uM.png"/> |
+| 0   | Rtp Tv | [>](http://flash2.xdevel.com/rtptv/rtptv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I1hYI0C.png"/> |
+| 0   | Rttr | [>](https://5f204aff97bee.streamlock.net/RTTRlive/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z7xMArA.png"/> |
+| 0   | Rtv 38 Toscana | [>](http://845d8509d2cb4f249dd0b2ae5755b6c2.msvdn.net/live/S12268608/CXHH7K39hg9K/playlist.m3u8) | <img height="20" src="https://i.imgur.com/xqlhJqK.png"/> |
+| 0   | Rtv Calabria | [>](https://59d7d6f47d7fc.streamlock.net/reggiotv/reggiotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ytwyx8D.png"/> |
+| 0   | SL 48 Tv | [>](http://media.velcom.it:1935/sl48/sl48/chunklist_w751971098.m3u8) | <img height="20" src="https://i.imgur.com/b58oouu.jpg"/> |
+| 0   | ST Europe Channel | [>](https://5f22d76e220e1.streamlock.net/steuropetv/steuropetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/T7kyY2p.png"/> |
+| 0   | Sardegna 1 | [>](https://59d8c0cee6f3d.streamlock.net/sardegnauno/sardegnauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qRRGn1e.png"/> |
+| 0   | Set Tv Cilento  | [>](https://stream1.aswifi.it/settv/live/index.m3u8) | <img height="20" src="https://i.imgur.com/qN5D1jD.png"/> |
+| 0   | Sicilia Media | [>](http://live.streamcaster.net:1935/siciliamediatv_live/siciliamedia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oQwo4AP.png"/> |
+| 0   | Sicilia Tv | [>](https://5f22d76e220e1.streamlock.net/SiciliaTV/SiciliaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I5FoThW.png"/> |
+| 0   | Sienatv | [>](https://flash8.xdevel.com/sienatv/sienatv/master.m3u8) | <img height="20" src="https://i.imgur.com/gcysky4.png"/> |
+| 0   | Siracusa Live Tv  | [>](https://5db313b643fd8.streamlock.net/SRLIVE_1/SRLIVE_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oyPkDnz.jpg"/> |
+| 0   | Sophia Tv | [>](https://www.onairport.live/sophiatv-it-live/livestream_low/chunklist_w217998957.m3u8) | <img height="20" src="https://i.imgur.com/fiLNK3b.jpg"/> |
+| 0   | Stiletv | [>](http://convision2.convergenze.it/hls-live/livepkgr/_definst_/liveevent/livestream1.m3u8) | <img height="20" src="https://i.imgur.com/v5Grhff.jpg"/> |
+| 0   | Studio 100 | [>](http://wms.shared.streamshow.it:1935/studio100ta/studio100ta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z84qFXd.png"/> |
+| 0   | Super J Tv | [>](http://uk4.streamingpulse.com:1935/SuperJtv/SuperJtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/5oy5Nuu.png"/> |
+| 0   | Super Six      | [>](https://5db313b643fd8.streamlock.net/SUPERSIXLombardia/SUPERSIXLombardia/playlist.m3u8) | <img height="20" src=""/> |
+| 0   | Supertv | [>](http://wms.shared.streamshow.it:1935/supertv/supertv/live.m3u8) | <img height="20" src="https://i.imgur.com/7gUZcEh.png"/> |
+| 0   | T.R.L Tele Radio Leo | [>](https://5db313b643fd8.streamlock.net/TRL/TRL/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qAagkJT.png"/> |
+| 0   | T.S.E. Uno (Tele Scout Europa) | [>](http://stream.mariatvcdn.com/tse/bd5a2cb40637623177295aed22db25f9.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OA0PRsb.png"/> |
+| 0   | T9 | [>](https://5f11919dca3bd.streamlock.net/t9/t9/chunklist_w1829149389.m3u8) | <img height="20" src="https://i.imgur.com/vlJaxJl.png"/> |
+| 0   | TRC Santeramo | [>](https://59d7d6f47d7fc.streamlock.net/trc/trc/playlist.m3u8) | <img height="20" src="https://i.imgur.com/VbYdS8P.jpg"/> |
+| 0   | TSD Tv Arezzo(Tele San Domenico) | [>](https://stream.mariatvcdn.com/tsd/7c59373bfdb38201b9215ff86f0ce6af.sdp/chunks.m3u8) | <img height="20" src="https://i.imgur.com/WQ8eQXc.png"/> |
+| 0   | TVL (TV Libera Pistoia) | [>](http://live.mariatvcdn.com/mariatvcdn/70564e1c6884c007c76f0c128d679eed.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/07geF0L.png"/> |
+| 0   | Tcf Tv | [>](http://live.sloode.com:1935/tcf_live/telecineforum/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fiylFs2.jpg"/> |
+| 0   | Tci | [>](https://player-api.new.livestream.com/accounts/27460990/events/8287184/broadcasts/223071659.secure.m3u8) | <img height="20" src="https://i.imgur.com/lCZTaKs.jpg"/> |
+| 0   | Teatro Tv | [>](https://m.iostream.it/hls/teatrotv/teatrotv.m3u8) | <img height="20" src="https://i.imgur.com/UsvffQL.png"/> |
+| 0   | Tele A | [>](http://82.62.190.94/hls/telea/video.m3u8) | <img height="20" src="https://i.imgur.com/l7Za9KH.jpg"/> |
+| 0   | Tele Abruzzo Tv | [>](http://uk4.streamingpulse.com:1935/TeleabruzzoTV/TeleabruzzoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/koB8J4b.jpg"/> |
+| 0   | Tele Acras | [>](https://5cbd3bc28341f.streamlock.net:444/teleacras/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/90Lsv8q.png"/> |
+| 0   | Tele Arena | [>](https://5e73cf528f404.streamlock.net/TeleArena/TeleArena.stream/chunklist_w188795637.m3u8) | <img height="20" src="https://i.imgur.com/9hsoWMO.png"/> |
+| 0   | Tele Argento/Magic Tv | [>](http://163.172.88.73:1935/magic_web/site/chunklist_w1342104039.m3u8) | <img height="20" src="https://i.imgur.com/gseTf4W.jpg"/> |
+| 0   | Tele Bari | [>](https://w1.mediastreaming.it/telebari/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HYSz4rx.png"/> |
+| 0   | Tele Belluno | [>](https://live.mariatvcdn.com/telebelluno/a3b80388da9801906adf885282e73bc3.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/YiM2Z7E.png"/> |
+| 0   | Tele Blu | [>](https://58d921499d3d3.streamlock.net/Teleblu/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NWMTlry.jpg"/> |
+| 0   | Tele Boario | [>](http://flash7.streaming.xdevel.com/teleboario/teleboario/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LlLD3L6.png"/> |
+| 0   | Tele Bruzzano | [>](https://player.ilariochiera.it/fileadmin/hls/Telebruzzano/telebruzzano_mediachunks.m3u8) | <img height="20" src="https://i.imgur.com/7TWbCDt.jpg"/> |
+| 0   | Tele Chiara | [>](http://fms.tvavicenza.it:1935/telechiara/diretta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Q5XpnXR.png"/> |
+| 0   | Tele Citta' Padova | [>](rtmp://stream.telepadova.com/live/tv1.flv) | <img height="20" src="https://i.imgur.com/xvVgEaA.jpg"/> |
+| 0   | Tele Citta' | [>](http://213.187.12.18/live/tv1.m3u8) | <img height="20" src="https://i.imgur.com/yWwLLOm.png"/> |
+| 0   | Tele Club Italia | [>](https://www.theclubfactory.com/streaming/index.m3u8) | <img height="20" src="https://i.imgur.com/WxkOgg0.png"/> |
+| 0   | Tele Clusone Bergamo | [>](https://media.streambrothers.com:1936/8546/8546/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dVDY1ng.png"/> |
+| 0   | Tele Color Lombardia | [>](http://cdn.mainstreaming.tv/live/324149/hlbAWtl/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hUA29XI.jpg"/> |
+| 0   | Tele Cupole | [>](http://live.livevideosolution.it/telecupole/dd6d85e5b7452f7b85a099509292b421.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ZmUI9zb.png"/> |
+| 0   | Tele Estense | [>](https://5e73cf528f404.streamlock.net/TeleEstense/livestream/chunklist_w530758405.m3u8) | <img height="20" src="https://i.imgur.com/X7i7DWo.png"/> |
+| 0   | Tele Foggia | [>](http://wms.shared.streamshow.it/telefoggia/mp4:telefoggia/chunklist_w386788975.m3u8) | <img height="20" src="https://i.imgur.com/M7tqBu9.jpg"/> |
+| 0   | Tele Friuli | [>](https://streamtechglobal.akamaized.net/hls/live/2024685/telefriuli/Group01/2024685-telefriuli/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/AoQxZxD.png"/> |
+| 0   | Tele Gela | [>](http://live.sloode.com:1935/qdg_live/AF74-FF2C-7350-41F2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sjrxbgP.png"/> |
+| 0   | Tele Genova | [>](https://5db313b643fd8.streamlock.net/Telegenova/Telegenova/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BXvPBKb.png"/> |
+| 0   | Tele Granda | [>](http://live.sloode.com:1935/telegranda_live/C2AD-0664-DC75-4744/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mdPc8cX.jpg"/> |
+| 0   | Tele Ischia | [>](https://eu1.servers10.com:8081/8130/index.m3u8) | <img height="20" src="https://i.imgur.com/vihHVQn.jpg"/> |
+| 0   | Tele Jonio | [>](http://59d7d6f47d7fc.streamlock.net/telejonio/telejonio/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qJeDV8R.png"/> |
+| 0   | Tele Lazio Nord | [>](http://tln.srfms.com:1935/TLN/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gZEojVW.png"/> |
+| 0   | Tele Liberta' HD | [>](https://player-api.new.livestream.com/accounts/17114188/events/4902226/broadcasts/223072237.secure.m3u8) | <img height="20" src="https://i.imgur.com/XzAB5k7.jpg"/> |
+| 0   | Tele Liguria Sud | [>](https://live.teleliguriasud.it/hls/tls/index.m3u8) | <img height="20" src="https://i.imgur.com/BeLAYJ6.jpg"/> |
+| 0   | Tele Mantova | [>](https://5ce9406b73c33.streamlock.net/TeleMantova/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bkSPcs4.png"/> |
+| 0   | Tele Mia Extra | [>](https://player.ilariochiera.it/fileadmin/hls/TelemiaExtra/stream.m3u8) | <img height="20" src="https://i.imgur.com/upzBG32.png"/> |
+| 0   | Tele Mia | [>](http://wms.shared.streamshow.it:80/telemia/telemia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/SdXpCwL.png"/> |
+| 0   | Tele Mistretta Life e Family | [>](https://stream.mariatvcdn.com/telemistrettalive2/ddbcd59a192d6f92336991e344fa1821.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/y2LLwiy.png"/> |
+| 0   | Tele Mistretta Radio | [>](https://stream.mariatvcdn.com/telemistrettaradio/900bfcc0f9012ea272584fd5ff5281b8.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/d7O7Uqa.png"/> |
+| 0   | Tele Mistretta | [>](https://live.mariatvcdn.com/telemistretta/8fbcd205ada81b295ee6c211c3a80dde.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OJ3zUS0.png"/> |
+| 0   | Tele Molise | [>](http://185.202.128.1:1935/TelemoliseStream/telemoliseTV.stream_tlm/chunklist_w1170267390.m3u8) | <img height="20" src="https://i.imgur.com/u5VD0x9.png"/> |
+| 0   | Tele Monteneve 3 | [>](http://wms.shared.streamshow.it/telemonteneve3/telemonteneve3/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LJhQApn.jpg"/> |
+| 0   | Tele Norba (TG Norba 24 )| [>](https://flash2.xdevel.com/tgnorba_24/tgnorba_24_source.stream/manifest.mpd) | <img height="20" src="https://i.imgur.com/9MhrrJK.png"/> |
+| 0   | Tele Nord Est | [>](https://59d7d6f47d7fc.streamlock.net/telenord/telenord/chunklist_w2111676469.m3u8) | <img height="20" src="https://i.imgur.com/TakoSUX.png"/> |
+| 0   | Tele Nord Genova | [>](https://5db313b643fd8.streamlock.net/Telenord/Telenord/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gQWB9Gx.png"/> |
+| 0   | Tele Nostra | [>](https://meridelive-lh.akamaihd.net/i/ottop_1@118465/index_1_av-p.m3u8?sd=10&amp;rebase=on) | <img height="20" src="https://i.imgur.com/FACahKZ.png"/> |
+| 0   | Tele Occidente | [>](http://ciaoitalystream.ddns.net/live/webTELEOCCIDENTEweb/montelepre@palermo/2.m3u8) | <img height="20" src="https://i.imgur.com/3aOiWKa.png"/> |
+| 0   | Tele Oltre | [>](http://1se1.troydesign.eu/np_teleoltre/_definst_/channel1_np_teleoltre/playlist.m3u8?ext=.m3u8) | <img height="20" src="https://i.imgur.com/PxtJAxs.png"/> |
+| 0   | Tele One | [>](http://live.streamcaster.net:1935/mediaone_live/teleone/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hTDDVOQ.png"/> |
+| 0   | Tele Pace 1 | [>](https://live.mariatvcdn.com/teleradiopace1/efcc8fc46cab26315ce3f5845d76008f.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/ut0Hg8o.png"/> |
+| 0   | Tele Pace 2 | [>](https://live.mariatvcdn.com/teleradiopace2/254c9b5c52a73a94ef0f6169cbd05dc2.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/RqrPraO.png"/> |
+| 0   | Tele Pace 3 | [>](https://live.mariatvcdn.com/teleradiopace3/d2274c22e9ee09eb2eda01ed0496f8f5.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/gLsE3mX.png"/> |
+| 0   | Tele Pace 4 | [>](https://live.mariatvcdn.com/teleradiopace4/13d74f2cfe921bfbc262697203d47d8f.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/tEQvgpz.png"/> |
+| 0   | Tele Pace News | [>](https://live.mariatvcdn.com/teleradiopace6/d289fe76f16ad32afec471ea1b941583.sdp/index.m3u8) | <img height="20" src="https://i.imgur.com/AxmgoMT.png"/> |
+| 0   | Tele Pace Roma | [>](https://live.mariatvcdn.com/mariatvpoint/d36592901d5429dd7f9ec1e7bbeda8c2.sdp/index.m3u8) | <img height="20" src="https://i.imgur.com/54oi0cg.png"/> |
+| 0   | Tele Pace Trento | [>](https://5a1178b42cc03.streamlock.net/telepacetrento/telepacetrento/playlist.m3u8) | <img height="20" src="https://i.imgur.com/o5sQCpF.png"/> |
+| 0   | Tele Pace Verona | [>](https://live.mariatvcdn.com/TelepaceVerona/a9027aba28cf4b54d10aedc38b0df192.sdp/index.m3u8) | <img height="20" src="https://i.imgur.com/su2ipkb.png"/> |
+| 0   | Tele Pavia | [>](http://wms.shared.streamshow.it:1935/telepavia/telepavia/live.m3u8) | <img height="20" src="https://i.imgur.com/YVodo4T.png"/> |
+| 0   | Tele Pegaso | [>](https://flash2.xdevel.com/telepegasocanale812/telepegasocanale812/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FQkM8Vd.png"/> |
+| 0   | Tele Piadena  | [>](https://stream3.xdevel.com/video0s975441-151/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/VqaPuQN.png"/> |
+| 0   | Tele Pordenone | [>](https://video.wifi4all.it/telepn/telepn.m3u8) | <img height="20" src="https://i.imgur.com/dbYwXwg.png"/> |
+| 0   | Tele Prima | [>](http://live.sloode.com:1935/teleprima/live/chunklist_w268781554.m3u8) | <img height="20" src="https://i.imgur.com/WLziQCV.png"/> |
+| 0   | Tele Quattro Trieste | [>](http://wms.shared.streamshow.it/telequattro/telequattro/chunklist_w1388066579.m3u8) | <img height="20" src="https://i.imgur.com/MFxQxve.png"/> |
+| 0   | Tele Radio Ercolano | [>](https://eu1.servers10.com:8081/8012/index.m3u8) | <img height="20" src="https://i.imgur.com/YPuoy8N.jpg"/> |																																												   
+| 0   | Tele Radio Orte | [>](https://flash2.xdevel.com/ortetv/ortetv/index.m3u8) | <img height="20" src="https://i.imgur.com/uX2uxvN.png"/> |
+| 0   | Tele Radio Sciacca | [>](http://5cbd3bc28341f.streamlock.net:1935/trs_live/teleradiosciacca-tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/suhz5mE.png"/> |
+| 0   | Tele Radio Studio 5 | [>](http://mars.az-streamingserver.com:1935/7444/7444/chunklist_w1479892021.m3u8) | <img height="20" src="https://i.imgur.com/lPRjSor.jpg"/> |
+| 0   | Tele Rama | [>](https://58d921499d3d3.streamlock.net/TeleRama/livestream/chunklist_w1747460348.m3u8) | <img height="20" src="https://i.imgur.com/enfqUlI.jpg"/> |
+| 0   | Tele Roma 1 | [>](https://flash2.xdevel.com/teleromauno/teleromauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3t7JWrf.png"/> |
+| 0   | Tele Romagna 24 | [>](http://livetr.teleromagna.it/mia/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Bpml478.png"/> |
+| 0   | Tele Romagna Lifestyle | [>](http://livetr.teleromagna.it/lifestyle/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gup84Sb.png"/> |
+| 0   | Tele Romagna Mia | [>](http://livetr.teleromagna.it/news/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/IdHPiQz.png"/> |
+| 0   | Tele Romagna | [>](http://livetr.teleromagna.it/teleromagna/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4jWadI8.png"/> |
+| 0   | Tele Sirio | [>](https://www.telesirio.it/live/stream.m3u8) | <img height="20" src="https://i.imgur.com/mDN6QX1.png"/> |
+| 0   | Tele Spazio Messina | [>](http://smart.telespazioplay.com:8080/play/stream.m3u8) | <img height="20" src="https://i.imgur.com/Io5w6lT.png"/> |
+| 0   | Tele Star 1 | [>](http://193.34.109.10:8090/) | <img height="20" src="https://i.imgur.com/UZQjEsd.png"/> |
+| 0   | Tele Sud Puglia | [>](https://webtv.pugliaservice.it:1936/telesud-webtv/telesud-webtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fqTLtvs.png"/> |
+| 0   | Tele Sveva News 24 | [>](https://dc1.telesveva.erefresh.it:4443/news24.mp4) | <img height="20" src="https://i.imgur.com/4HlRpf4.jpg"/> |
+| 0   | Tele Tebe | [>](https://5c389faa13be3.streamlock.net:9553/calabriasat/calabriasat/playlist.m3u8) | <img height="20" src="https://i.imgur.com/YirYT4J.png"/> |
+| 0   | Tele Terni | [>](https://diretta.teleterni.it/live/stream_src.m3u8) | <img height="20" src="https://i.imgur.com/lslSS3a.jpg"/> |
+| 0   | Tele Tricolore | [>](https://59d7d6f47d7fc.streamlock.net/rs2/rs2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/A2XouAd.png"/> |
+| 0   | Tele Tutto 2 | [>](https://600f07e114306.streamlock.net/TT2_TELETUTTO/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mxXbMaw.png"/> |
+| 0   | Tele Tutto 24 | [>](https://600f07e114306.streamlock.net/TT24_TELETUTTO/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/weKWQgx.png"/> |
+| 0   | Tele Tutto | [>](https://600f07e114306.streamlock.net/TT_TELETUTTO/smil:TT.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sZxMP7g.png"/> |
+| 0   | Tele Venezia | [>](https://59d8c0cee6f3d.streamlock.net/televenezia/televenezia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/SavGpCE.jpg"/> |
+| 0   | Tele Video Agrigento (T.V.A.) | [>](https://59d7d6f47d7fc.streamlock.net/tva/tva/chunklist_w2057719642.m3u8) | <img height="20" src="https://i.imgur.com/AaPr63E.png"/> |
+| 0   | TeleMajg | [>](https://59d7d6f47d7fc.streamlock.net/telemajg/telemajg/chunklist_w656612441.m3u8) | <img height="20" src="https://i.imgur.com/9tefonp.jpg"/> |
+| 0   | TeleRent 7Gold | [>](http://stream2.xdevel.com/video0s86-21/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wjZT8De.png"/> |
+| 0   | Telesud Trapani | [>](https://5cbd3bc28341f.streamlock.net:444/telesud/_definst_/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/tpZvU1P.png"/> |
+| 0   | Teleuniverso | [>](https://media.velcom.it:19360/teleuniverso/teleuniverso.m3u8) | <img height="20" src="https://i.imgur.com/u8E9wBb.png"/> |
+| 0   | Televallo Trapani | [>](https://5cbd3bc28341f.streamlock.net:444/televallo/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/P6zuiRH.png"/> |
+| 0   | Tevere Tv | [>](https://5926fc9c7c5b2.streamlock.net/9098/9098/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ghBX2Hn.png"/> |
+| 0   | Touring Tv | [>](https://flash2.xdevel.com/radiotouring10496/radiotouring10496_aac/playlist.m3u8) | <img height="20" src="https://i.imgur.com/E2Feao5.jpg"/> |
+| 0   | Trentino Tv | [>](https://5e73cf528f404.streamlock.net/TrentinoTV/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ROKOCR2.png"/> |
+| 0   | Tris News | [>](https://5db313b643fd8.streamlock.net/WLTV/WLTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/zasGDNl.jpg"/> |
+| 0   | Tris Siracusa | [>](https://5db313b643fd8.streamlock.net/Tris/Tris/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dZgKD3j.jpg"/> |
+| 0   | Trm H24 | [>](http://w1.streamingmedia.it:1935/trmh24/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/eWV9yII.png"/> |
+| 0   | Tsn Lecco | [>](http://59d8c0cee6f3d.streamlock.net/tsn2/tsn2_mobile/playlist.m3u8) | <img height="20" src="https://i.imgur.com/vlyaN3U.jpg"/> |
+| 0   | Tsn Tele Sondrio News | [>](http://wms.shared.streamshow.it/tsn/tsn_mobile/playlist.m3u8) | <img height="20" src="https://i.imgur.com/24Anl5o.png"/> |
+| 0   | Tua Channel | [>](https://media2021.rtvweb.com/promovideo_web/tuachannel/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BDdQvtS.png"/> |
+| 0   | Tuscia Sabina 2000Tv | [>](http://ts2000tv.streaming.nextware.it:8081/ts2000tv/ts2000tv/chunks.m3u8) | <img height="20" src="https://i.imgur.com/Tq5nEAy.png"/> |
+| 0   | Tv 6 | [>](http://185.202.128.1:1935/Tv6Stream/tv6TV.stream_tlm/chunklist_w16775241.m3u8) | <img height="20" src="https://i.imgur.com/bJ2e604.png"/> |
+| 0   | Tv Campane 1 | [>](https://eu1.servers10.com:8081/8032/index.m3u8) | <img height="20" src="https://i.imgur.com/UrHKovD.jpg"/> |
+| 0   | Tv Campania Streaming | [>](https://eu1.servers10.com:8081/8020/index.m3u8) | <img height="20" src="https://i.imgur.com/5Ly6LyC.png"/> |
+| 0   | Tv Luna Napoli  | [>](https://streamlive.arcapuglia.it:8080/live/teleluna/index.m3u8) | <img height="20" src="https://i.imgur.com/jxhuoyE.png"/> |
+| 0   | Tv Prato | [>](https://live.mariatvcdn.com/tvprato/2db0dd5674586686a867ec52c3aa8e06.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/zDeVpZd.png"/> |
+| 0   | Tv Qui Modena | [>](https://59d7d6f47d7fc.streamlock.net/tvqui/tvqui/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4bOYlfg.png"/> |
+| 0   | Tv Uno | [>](http://ftp.tiscali.it/francescovernata/TVUNO/monoscopioTvUNOint-1.wmv) | <img height="20" src="https://i.imgur.com/OtCwYsh.jpg"/> |
+| 0   | Tv7 Azzurra | [>](http://217.61.26.46:8080/hls/azzurra.m3u8) | <img height="20" src="https://i.imgur.com/yYvGWHL.png"/> |
+| 0   | Tv7 News | [>](http://217.61.26.46:8080/hls/news.m3u8) | <img height="20" src="https://i.imgur.com/rlMEE1j.png"/> |
+| 0   | Tv7 Triveneta | [>](http://217.61.26.46:8080/hls/triveneta.m3u8) | <img height="20" src="https://i.imgur.com/O2NF7jJ.jpg"/> |
+| 0   | Tva Agrigento | [>](https://59d7d6f47d7fc.streamlock.net/tva/tva/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6dxp79F.png"/> |
+| 0   | Tva Vicenza | [>](http://fms.tvavicenza.it:1935/live/diretta_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FtFuPCC.png"/> |
+| 0   | Tvr Xenon | [>](https://cloudtv.azotosolutions.com:9553/tvrxenonlive/tvrxenonlive/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kLzW1Pf.jpg"/> |
+| 0   | Tvrs Tv | [>](https://59d7d6f47d7fc.streamlock.net/tvrs/tvrs/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6p7hTmY.jpg"/> |
+| 0   | Umbria TV  | [>](https://umbriatv.stream.rubidia.it:8083/live/umbriatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kccGe02.png"/> |
+| 0   | Uninettuno University Tv  | [>](https://stream6-rai-it.akamaized.net/live/uninettuno/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/awnuxMY.png"/> |
+| 0   | Vera Tv | [>](http://wms.shared.streamshow.it/veratv/veratv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/djMvkvN.png"/> |
+| 0   | Video 33 | [>](http://livestream.goinfo.it/V33Live/v33ros/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Wp24htV.jpg"/> |
+| 0   | Video Brescia | [>](http://wms.shared.streamshow.it/videobrescia/videobrescia/hasbahca.m3u8) | <img height="20" src="https://i.imgur.com/9Fw2wBT.png"/> |
+| 0   | Video Mediterraneo | [>](http://stream.ets-sistemi.it:1935/live.rvm/rvmtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hJHC3uQ.png"/> |
+| 0   | Video Nola | [>](http://stream1.aswifi.it/videonola/live/index.m3u8) | <img height="20" src="https://i.imgur.com/M5z5UoD.jpg"/> |
+| 0   | Video Star | [>](https://5cbd3bc28341f.streamlock.net:444/videostar_live/_definst_/videostar/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1ddJVZ7.jpg"/> |
+| 0   | Videolina | [>](http://livestreaming.videolina.it/live/Videolina/chunklist_w488279894.m3u8) | <img height="20" src="https://i.imgur.com/bnDZJwd.gif"/> |
+| 0   | Videostar Tv Lombardia | [>](http://dreamsiteradiocpvideo.com:1935/vds/vds/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ecpPFZL.jpg"/> |
+| 0   | Vuemme Tv | [>](https://5db313b643fd8.streamlock.net/Vuemme/Vuemme/chunklist_w1853927005.m3u8) | <img height="20" src="https://i.imgur.com/x5A0xU6.png"/> |
+| 0   | Well Tv | [>](https://59d7d6f47d7fc.streamlock.net/welltv/welltv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Kqgz4Na.png"/> |
+| 0   | Yvii Tv | [>](rtmp://yviistreamer.kernel.online:1935/live/yviitv) | <img height="20" src="https://i.imgur.com/yP5AvDo.png"/> |
+| 0   | Zerouno Tv News | [>](https://5db313b643fd8.streamlock.net/ZerounoTVEventi/ZerounoTVEventi/playlist.m3u8) | <img height="20" src="https://i.imgur.com/vxRzyjE.png"/> |
 
 <h2>Samsung TV Plus</h2>
 
@@ -83,6 +371,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 4101 | Humanity Documentari | [>](https://alchimie-humanity-3-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/k5KusfQ.jpg"/> |
 | 4250 | Yamato Animation | [>](https://yamatovideo-yamatoanimation-1-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rOl7HfS.png"/> |
 | 4251 | Big Name       | [>](https://alchimie-big-names-3-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FsjPjTb.png"/> |
+| 4253 | FailArmy       | [>](https://failarmy-international-it.samsung.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/JmQ6QjL.png"/> |
 | 4254 | The Pet Collective | [>](https://the-pet-collective-international-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/daTU44g.jpeg"/> |
 | 4255 | Spotlight – Rakuten TV | [>](https://rakuten-spotlight-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6gEPwNN.jpg"/> |
 | 4256 | People Are Awesome | [>](https://jukin-peopleareawesome-2-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/xwz9zKk.jpeg"/> |
@@ -101,13 +390,13 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 4503 | Cinema Segreto | [>](https://minerva-cinemasegreto-1-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BkzplSs.png"/> |
 | 4504 | CGtv           | [>](https://cgentertainment-cgtv-1-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6rsLtY7.png"/> |
 | 4508 | Sofy.tv        | [>](https://sofytv-samsungit.amagi.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fsJFJeZ.png"/> |
+| 4510 | Dark Matter TV | [>](https://amg00434-tricoast-darkmatter-italy-samsunguk-lvse1.amagi.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Stm6Zc9.png"/> |
 | 4547 | Documentari – Rakuten TV | [>](https://rakuten-documentaries-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rAHBiO8.jpg"/> |
 | 4548 | Family – Rakuten TV | [>](https://rakuten-family-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BCC123A.jpg"/> |
 | 4549 | Drammatico – Rakuten TV | [>](https://rakuten-tvshows-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Nx3JzZK.jpg"/> |
 | 4550 | Film d'azione – Rakuten TV | [>](https://rakuten-actionmovies-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KDmDQM6.jpg"/> |
-| 4510 | Dark Matter | [>](https://amg00434-tricoast-darkmatter-italy-samsunguk-lvse1.amagi.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Stm6Zc9.png"/> |
-| 4253 | Fail Army | [>](https://failarmy-international-it.samsung.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/JmQ6QjL.png"/> |
-| 124 | Rakuten Classico | [>](https://rakuten-classico-1-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
+| 5000 | Classico – Rakuten TV | [>](https://rakuten-classico-1-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
+| 5001 | Film Top – Rakuten TV | [>](https://rakuten-topfree-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
 
 <h2>Invalid</h2>
 
@@ -121,295 +410,3 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 44  | Frisbee        | [x](https://sbshdlu1-lh.akamaihd.net/i/sbshdl_21@443313/master.m3u8) | <img height="20" src="https://i.imgur.com/9y1zIAe.png"/> |
 | 56  | HGTV – Home & Garden Tv  | [x](https://sbshdlu5-lh.akamaihd.net/i/sbshdl_7@106896/master.m3u8) | <img height="20" src="https://i.imgur.com/emLNC0U.png"/> |
 | 58  | Rai Sport Ⓢ Ⓖ | [x](https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=179975) | <img height="20" src="https://i.imgur.com/xsGljsb.png"/> |
-
-
-<h2>Regionali</h2>
-
-| #   | Channel        | Link  | Logo |
-|:---:|:--------------:|:-----:|:-----:
-| 126 | 111 Tv | [>](https://5db313b643fd8.streamlock.net/111TV/111TV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4jY8yAI.png"/> |
-| 127 | 12 Tv Parma | [>](https://meridelive01-lh.akamaihd.net/i/tvparma_1@356964/master.m3u8) | <img height="20" src="https://i.imgur.com/xnUgx6b.png"/> |
-| 128 | 696 Tv | [>](https://meridelive-lh.akamaihd.net/i/ottop_1@118465/index_1_av-p.m3u8?sd=10&rebase=on) | <img height="20" src="https://i.imgur.com/i6PJJDU.png"/> |
-| 129 | 8 Video Calabria | [>](http://wms.shared.streamshow.it:80/videocalabria/videocalabria/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9bVuiaQ.png"/> |
-| 130 | AB Channel  | [>](https://tsw.streamingwebtv24.it:1936/abchanneltv/abchanneltv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ze2xvoY.png"/> |
-| 131 | Abc Tv | [>](https://streamlive.arcapuglia.it:8080/live/abctv/index.m3u8) | <img height="20" src="https://i.imgur.com/nVmIeTD.png"/> |
-| 132 | Alpa 1 | [>](http://live.streamcaster.net:1935/alpauno/alpauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4QKFtUa.png"/> |
-| 133 | Alpa 1 | [>](http://live.streamcaster.net:1935/alpauno/alpauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4QKFtUa.png"/> |
-| 134 | Alto Adige Tv | [>](https://5f204aff97bee.streamlock.net/AltoAdigeTV/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/S2sCFQi.png"/> |
-| 135 | Antenna 2 Bergamo | [>](https://58f12ffd2447a.streamlock.net/Antenna2/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NfvHIAw.png"/> |
-| 136 | Antenna 3 Massa | [>](http://163.172.88.73:1935/antenna3massa/a3/playlist.m3u8) | <img height="20" src="https://i.imgur.com/79dWgVB.png"/> |
-| 137 | Antenna 3 Veneto Nord Est | [>](https://59d8c0cee6f3d.streamlock.net/antennatreveneto/antennatreveneto.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NiVHLwp.png"/> |
-| 138 | Antenna Sud 13 | [>](https://streamlive13.arcapuglia.it:8080/live/antennasud/index.m3u8) | <img height="20" src="https://i.imgur.com/VCn0g3a.png"/> |
-| 139 | Antenna Sud 174 | [>](https://streamlivesud.arcapuglia.it:8080/live/eventi/index.m3u8) | <img height="20" src="https://i.imgur.com/02dXr31.png"/> |
-| 140 | Antenna Sud 299 | [>](https://streamlivesud.arcapuglia.it:8080/live/cult/index.m3u8) | <img height="20" src="https://i.imgur.com/XuIXCKg.png"/> |
-| 141 | Antenna Sud 85 | [>](https://streamlive85.arcapuglia.it:8080/live/canale85/index.m3u8) | <img height="20" src="https://i.imgur.com/0JM7Jw0.png"/> |
-| 142 | Antenna Sud 90 | [>](https://streamlivesud.arcapuglia.it:8080/live/teleonda/index.m3u8) | <img height="20" src="https://i.imgur.com/jsGagGp.png"/> |
-| 143 | Apulia Web Tv | [>](https://cp1.server89.com:19360/apuliawebtv/apuliawebtv.m3u8) | <img height="20" src="https://i.imgur.com/AnU4g2J.png"/> |
-| 144 | Aurora Arte | [>](https://59d7d6f47d7fc.streamlock.net/auroraarte/auroraarte/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/BoLZ5wG.png"/> |
-| 145 | Azzurra Tv Vco | [>](http://sb.top-ix.org:1935/avtvlive/streaming/chunklist_w1605488247.m3u8) | <img height="20" src="https://i.imgur.com/mSWw8uW.png"/> |
-| 146 | Basilicata 1 Tv | [>](http://77.68.40.210:8888/hls/basilicata1.m3u8) | <img height="20" src="https://i.imgur.com/VS6CQ88.png"/> |
-| 147 | Bergamo Tv | [>](http://api.new.livestream.com/accounts/245066/events/3063596/live.m3u8) | <img height="20" src="https://i.imgur.com/1doR6Vl.png"/> |
-| 148 | Byoblu Tv | [>](https://player-api.new.livestream.com/accounts/29084624/events/9394322/broadcasts/223051863.secure.m3u8) | <img height="20" src="https://i.imgur.com/KldC2gI.png"/> |
-| 149 | Cafe Tv 24 | [>](http://srv3.meway.tv:1957/cafe/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KbcbxFw.png"/> |
-| 150 | Calabria Uno TV  | [>](https://5f22d76e220e1.streamlock.net/calabriaunotv/calabriaunotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2TK1GQ5.png"/> |
-| 151 | Calabria tv | [>](https://5db313b643fd8.streamlock.net:443/CalabriaTv2/CalabriaTv2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qWirucd.png"/> |
-| 152 | Canale 10 | [>](http://37.187.142.147:1935/ch10live/high.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KuQcjYV.png"/> |
-| 153 | Canale 12 Sassari | [>](http://wifitv.tv/media/live/1001/video_850000.m3u8) | <img height="20" src="https://i.imgur.com/u6P2lTY.jpg"/> |
-| 154 | Canale 16 | [>](https://5f11919dca3bd.streamlock.net/Canale16/Canale16/playlist.m3u) | <img height="20" src="https://i.imgur.com/SPfgKHk.png"/> |
-| 155 | Canale 18 | [>](https://5f11919dca3bd.streamlock.net/Canale18/Canale18/playlist.m3u8) | <img height="20" src="https://i.imgur.com/PZBX4iy.png"/> |
-| 156 | Canale 2 | [>](https://59d7d6f47d7fc.streamlock.net/canale2/canale2/chunklist_w811855890.m3u8) | <img height="20" src="https://i.imgur.com/ETqDkS1.png"/> |
-| 157 | Canale 21 Campania | [>](https://stream.mariatvcdn.com/canaleventuno/f5d2060b3682e0dfffd5b2f18e935ad3.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KVh8cOR.png"/> |
-| 158 | Canale 58 | [>](https://dotfvxkfj90ca.cloudfront.net/live/canale58_aac/master.m3u8) | <img height="20" src="https://i.imgur.com/RlFc74C.png"/> |
-| 159 | Canale 7 | [>](http://wms.shared.streamshow.it:80/canale7/canale7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9cuOLCn.png"/> |
-| 160 | Canale 74 Sicilia | [>](http://stream.ets-sistemi.it:1935/live.canale74/canale74tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/18JIVgu.png"/> |
-| 161 | Canale 8 | [>](https://59d8c0cee6f3d.streamlock.net/canale8/canale8/chunklist_w592700549.m3u8) | <img height="20" src="https://i.imgur.com/ElAS2WC.png"/> |
-| 162 | Canale Italia 83 | [>](http://ovp-live.akamaized.net/ac024_live/video1/chunklist.m3u8?accessToken=51c3544ac33a24b012ba69bf6349db78) | <img height="20" src="https://i.imgur.com/ZaenpJA.jpg"/> |
-| 163 | Canale Uno Tivù | [>](https://eu1.servers10.com:8081/8096/index.m3u8) | <img height="20" src="https://i.imgur.com/hfqNw92.png"/> |
-| 164 | Carina Tv | [>](http://wms.shared.streamshow.it/carinatv/mp4:carinatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FMGcm6I.jpg"/> |
-| 165 | Casa del Sole Tv | [>](https://eu1.servers10.com:8081/8040/index.m3u8) | <img height="20" src="https://i.imgur.com/qPdGelu.png"/> |
-| 166 | Castrovillari Tv | [>](rtmp://msh0062.stream.seeweb.it:1935/live/stream00.sdp) | <img height="20" src="https://i.imgur.com/V0kjYNG.png"/> |
-| 167 | Cilento Channel | [>](https://streaming.dimind.it/live/cilentocnn/index.m3u8) | <img height="20" src="https://i.imgur.com/4k9Su8j.png"/> |
-| 168 | Cremona 1 | [>](https://59d8c0cee6f3d.streamlock.net/cremona1/cremona1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a5d0F01.jpg"/> |
-| 169 | Di.Tv 90 | [>](http://163.172.88.73:1935/di_tv_90/live/chunklist_w707472623.m3u8) | <img height="20" src="https://i.imgur.com/ul0o7zv.png"/> |
-| 170 | Digital Tv7 Benevento | [>](http://streaming.senecadot.com/live/flv:tv7.sdp/chunklist_w132253248.m3u8) | <img height="20" src="https://i.imgur.com/NaQkklP.png"/> |
-| 171 | Donna tv | [>](https://5f11919dca3bd.streamlock.net/donnatv/donnatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/r4laYMh.png"/> |
-| 172 | E'live Brescia Tv | [>](https://59d7d6f47d7fc.streamlock.net/elivebresciatv/elivebresciatv/chunklist_w1234149773.m3u8) | <img height="20" src="https://i.imgur.com/bZ3B7pi.png"/> |
-| 173 | Easy Tv | [>](https://streamlive.arcapuglia.it:8080/live/canale190/index.m3u8) | <img height="20" src="https://i.imgur.com/LKrVuRR.jpg"/> |
-| 174 | Entella Tv | [>](https://5f22d76e220e1.streamlock.net:443/EntellaTV/EntellaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1VPXKrW.png"/> |
-| 175 | Espansione Tv | [>](https://srvx1.selftv.video/espansione/smil:live.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mm9HKpD.png"/> |
-| 176 | Esperia Tv | [>](http://wms.shared.streamshow.it/esperiatv/esperiatv/chunklist_w1096393748.m3u8) | <img height="20" src="https://patbuweb.com/tivustream/chanlogoz/ita/esperiatv.png"/> |
-| 177 | Etna Espresso Channel | [>](https://5db313b643fd8.streamlock.net/Etnachannelponte/Etnachannelponte/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hMUxytZ.png"/> |
-| 178 | Etv Marche | [>](https://live.ipstream.it/etvmarche/etvmarche.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4UO7q69.png"/> |
-| 179 | Etv Rete7 | [>](https://live.ipstream.it/etv/etv.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gwj65qg.jpg"/> |
-| 180 | Euro Tv | [>](https://5f22d76e220e1.streamlock.net/eurotv/eurotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HCl5Zbu.png"/> |
-| 181 | FM Tv Marche | [>](https://cloudtv.azotosolutions.com:9553/media/media/playlist.m3u8) | <img height="20" src="https://i.imgur.com/yY01NhL.jpg"/> |
-| 182 | Fano Tv (Canale17) | [>](https://5cbd3bc28341f.streamlock.net:444/fanotv_live/_definst_/43DA-3923-9C72-4E9F/chunklist_w1207024846.m3u8) | <img height="20" src="https://i.imgur.com/39oS1s4.jpg"/> |
-| 183 | GRP Televisione | [>](https://5cbd3bc28341f.streamlock.net:444/grp/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1zNPpVE.png"/> |
-| 184 | Giornale Radio Tv | [>](https://5db313b643fd8.streamlock.net:443/GiornaleRadioTelevision/GiornaleRadioTelevision/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TMtvCLL.jpg"/> |
-| 185 | Gold 78 HD  | [>](http://stream2.xdevel.com/video1s86-22/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/2UHu1ye.png"/> |
-| 186 | Gold Tv  | [>](http://151.0.207.99:1935/GoldTV/GOLD_17/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3rVi4kD.png"/> |
-| 187 | HUB Tv | [>](https://5c483b9d1019c.streamlock.net/8004/8004/playlist.m3u8) | <img height="20" src="https://i.imgur.com/46GTBEW.png"/> |
-| 188 | Icaro Tv Rimini | [>](https://59d7d6f47d7fc.streamlock.net/icarotv/icarotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z05VSSN.png"/> |
-| 189 | Idea Plus | [>](https://eu1.servers10.com:8081/8044/index.m3u8) | <img height="20" src="https://i.imgur.com/2edmxYF.png"/> |
-| 190 | Italia 2 | [>](https://59d7d6f47d7fc.streamlock.net/italia2/italia2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ISbxfY0.png"/> |
-| 191 | Italia 7 | [>](http://151.0.207.99:1935/italia7/italia7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/YBXkY4w.png"/> |
-| 192 | Iunior Tv | [>](https://5f22d76e220e1.streamlock.net/iuniortv/iuniortv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9jeNlLE.png"/> |
-| 193 | L'Altro Corriere Tv  | [>](https://stream.ets-sistemi.it/live.laltrocorrieretv/laltrocorrieretv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dgj79J3.png"/> |
-| 194 | La Tua Tv | [>](https://wms2.zivoli.it/latuatv/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Nc3I0cS.png"/> |
-| 195 | La3 Marsala | [>](https://tsw.streamingwebtv24.it:1936/eslife1/eslife1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/XlxpfEx.png"/> |
-| 196 | LaC News 24 | [>](https://cdn.mainstreaming.tv/live/100532/HVvPMzy/playlist.m3u8?rnd=861954) | <img height="20" src="https://i.imgur.com/02vCECa.png"/> |
-| 197 | LaC Tv Calabria | [>](http://streamcdnb9-f5842579ff984c1c98d63b8d789673eb.msvdn.net/live/100197/SOrBDPy/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2Ef6crS.png"/> |
-| 198 | Lab Tv | [>](http://live.sloode.com:1935/labtv_live/labtv/chunklist_w2038941170.m3u8) | <img height="20" src="https://i.imgur.com/OpRS6Fl.png"/> |
-| 199 | Lazio Tv | [>](http://151.0.207.99:1935/live/LAZIOTV12/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6gbWHvP.jpg"/> |
-| 200 | Le Cronache Lucane Tv | [>](http://stucazz.com:8888/hls/cronache.m3u8) | <img height="20" src="https://i.imgur.com/EBY3IZL.jpg"/> |
-| 201 | Lira Tv | [>](https://5e06222f4d978.streamlock.net/liratv/liratv1500/chunklist_w409119112.m3u8) | <img height="20" src="https://i.imgur.com/S0ReVEo.png"/> |
-| 202 | Lombardia Tv | [>](https://5db313b643fd8.streamlock.net/LOMBARDIATV/LOMBARDIATV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/aksVy9f.jpg"/> |
-| 203 | Love in Venice | [>](http://59d7d6f47d7fc.streamlock.net/loveinvenice/loveinvenice/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lLBzzce.png"/> |
-| 204 | Lucania Tv | [>](http://wms.shared.streamshow.it:80/lucaniatv/lucaniatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wuUNVR5.png"/> |
-| 205 | Made in BO | [>](https://srvx1.selftv.video/dmchannel/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WFnrMS0.png"/> |
-| 206 | Media Tv | [>](http://live.sloode.com:1935/mediatv/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WFiRWO9.png"/> |
-| 207 | Mediterranea Tv | [>](https://59bb40cf810aa.streamlock.net:4443/streamingvincente/streamingvincente/chunklist_w1462632196.m3u8) | <img height="20" src="https://i.imgur.com/GUTOqRt.png"/> |
-| 208 | Medjugorje Italia Tv | [>](https://5f22d76e220e1.streamlock.net/medjugorjeitaliatv/medjugorjeitaliatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hkZScXf.png"/> |
-| 209 | Medjugorje Tv Puglia  | [>](https://streamlive.arcapuglia.it:8080/live/medjugorietv/index.m3u8) | <img height="20" src="https://i.imgur.com/IWBeddh.png"/> |
-| 210 | Minformo Tv | [>](https://5db313b643fd8.streamlock.net:443/MinformoTV/MinformoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/VJNtnZM.jpg"/> |
-| 211 | NTI Canale 271 | [>](https://www.ntimedia.it/video/S0/S0_master.m3u8) | <img height="20" src="https://i.imgur.com/zlmcUe0.jpg"/> |
-| 212 | Napoli Nova Tv | [>](https://stream1.aswifi.it/napolinova/live/index.m3u8) | <img height="20" src="https://i.imgur.com/P5Boz0e.jpg"/> |
-| 213 | New Signal Tv Genova | [>](https://5f22d76e220e1.streamlock.net/NewSignalTV/NewSignalTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/5uGTCJn.png"/> |
-| 214 | Nuova TV Nazionale | [>](https://stream4.xdevel.com/video0s975955-782/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QWlRuXg.png"/> |
-| 215 | Nuova Tv 1  | [>](https://nuovatv.net:8443/tv/stream.m3u8) | <img height="20" src="https://i.imgur.com/1yqTZhR.png"/> |
-| 216 | Nuova Tv 2 | [>](https://nuovatv.net:8443/tv2/stream.m3u8) | <img height="20" src="https://i.imgur.com/0vauyV3.png"/> |
-| 217 | Ofanto Tv | [>](http://media.az-mediaserver.com:1935/7446/7446/chunklist_w454796868.m3u8) | <img height="20" src="https://i.imgur.com/UCgATWn.png"/> |
-| 218 | Onda Novara Tv | [>](https://585b674743bbb.streamlock.net/9006/9006/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Qoh9CFy.png"/> |
-| 219 | Onda Tv Sicilia | [>](https://5926fc9c7c5b2.streamlock.net/9040/9040/playlist.m3u8) | <img height="20" src="https://i.imgur.com/0c5Y6lr.png"/> |
-| 220 | Onda Web Radio | [>](http://178.33.224.197:1935/ondaradioweb/ondaradioweb/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3hTvrC8.jpg"/> |
-| 221 | One Tv E.R. | [>](https://5db313b643fd8.streamlock.net:443/OneTvEmilia/OneTvEmilia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/iAg0Kjl.png"/> |
-| 222 | Ora Tv | [>](https://5db313b643fd8.streamlock.net/OraTv/OraTv/chunklist_w1858583108.m3u8) | <img height="20" src="https://i.imgur.com/clWVrvE.png"/> |
-| 223 | Orler Tv | [>](https://w1.mediastreaming.it/orlertv/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dBkxD8e.png"/> |
-| 224 | Paradise Tv | [>](https://tsw.streamingwebtv24.it:1936/paradisetv/paradisetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/okIBfIb.jpg"/> |
-| 225 | Partenope Tv | [>](https://streamlive.arcapuglia.it:8080/live/partenopetv/index.m3u8) | <img height="20" src="https://i.imgur.com/FtuWkj1.png"/> |
-| 226 | Passione Lotto Tv | [>](http://185.63.52.103:8080/hls/passionelotto/1_2/index.m3u8) | <img height="20" src="https://i.imgur.com/E2JBphv.jpg"/> |
-| 125 | Pop Tv | [>](https://59d7d6f47d7fc.streamlock.net/poptv/poptv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TeolCu9.png"/> |
-| 227 | PrimAntenna TV | [>](https://585b674743bbb.streamlock.net:443/9062/9062/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gSklP3y.png"/> |
-| 228 | Prima Napoli Tv | [>](https://stream1.aswifi.it/primatvnapoli/live/index.m3u8) | <img height="20" src="https://i.imgur.com/yPuQeEy.jpg"/> |
-| 229 | Prima Tivvù | [>](https://streamtechglobal.akamaized.net/hls/live/2024751/primativvu/Group02/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oUGS2Nt.png"/> |
-| 230 | Prima Tv Sicilia | [>](https://5db313b643fd8.streamlock.net/PrimaTV/PrimaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ivkFRZ1.jpg"/> |
-| 231 | Prima Tv | [>](http://flash2.streaming.xdevel.com/primatv/primatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/br45JER.png"/> |
-| 232 | Primantenna Torino | [>](https://585b674743bbb.streamlock.net/9062/9062/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sqEcPFs.gif"/> |
-| 233 | Primocanale | [>](https://msh0203.stream.seeweb.it/live/flv:stream2.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/xWF1A1U.png"/> |
-| 234 | Promovideo Tv | [>](https://media2021.rtvweb.com/promovideo_web/promovideo/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MwK9HVG.png"/> |
-| 235 | Quarto Canale Flegreo | [>](http://live.mariatvcdn.com/dialogos/171e41deedf405f10c7dd6311387fb43.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/8RKY3Du.png"/> |
-| 236 | R+Tv Abruzzo | [>](https://54627d4fc5996.streamlock.net/rnews/rnews/playlist.m3u8) | <img height="20" src="https://i.imgur.com/jKVvT3K.jpg"/> |
-| 237 | R.T.C. Quarta Rete | [>](https://msh0232.stream.seeweb.it/live/stream00.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rFGA6qL.png"/> |
-| 238 | R.T.C. Telecalabria | [>](https://w1.mediastreaming.it/calabriachannel/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/tTYLcuh.jpg"/> |
-| 239 | R.T.I. Calabria | [>](https://stream.ets-sistemi.it/live.rti/rti-calabria/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hVzEvmo.jpg"/> |
-| 240 | RDE Tv | [>](https://visual.shoutca.st:1936/saiuz2/rde/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NiwPlrr.png"/> |
-| 241 | Radio Colonna Tv | [>](https://5f22d76e220e1.streamlock.net/rctv/rctv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/EcQvDfq.png"/> |
-| 242 | Radio Italia Cina Tv | [>](https://585b674743bbb.streamlock.net/9054/9054/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QGkyrO3.png"/> |
-| 243 | Radio Monte Kronio Tv (R.M.K.) | [>](http://vod1.kronopress.com:1935/tmk_live/5123-CA5C-9EBE-428A/chunklist_w758377964.m3u8) | <img height="20" src="https://i.imgur.com/t0I2Shi.jpg"/> |
-| 244 | Reggio Tv | [>](https://59d7d6f47d7fc.streamlock.net/reggiotv/reggiotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/merrg2C.png"/> |
-| 245 | Rete 55 | [>](https://stream.internet.one/Rete55_Live/index.m3u8) | <img height="20" src="https://i.imgur.com/EsZn2cj.png"/> |
-| 246 | Rete 7 Tv | [>](https://stream.ets-sistemi.it/live.rete7/rete7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lUTxfoh.png"/> |
-| 247 | Rete 8 Vga | [>](https://604e46ac2bdee.streamlock.net:1936/rete8_1/rete8_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3wF2AJX.jpg"/> |
-| 248 | Rete 8 | [>](https://dcunilive263-lh.akamaihd.net/i/dclive_1@348290/index_150_av-p.m3u8?sd=10&rebase=on) | <img height="20" src="https://i.imgur.com/5WLYqLx.jpg"/> |
-| 249 | Rete Biella | [>](https://sb.top-ix.org/retebiella/streaming/playlist.m3u8) | <img height="20" src="https://i.imgur.com/e2ryHx7.png"/> |
-| 250 | Rete Chiara | [>](https://cp1.server89.com:19360/mediamasterpress/mediamasterpress.m3u8) | <img height="20" src="https://i.imgur.com/viL8ZrS.png"/> |
-| 251 | Rete Mia  | [>](https://5db313b643fd8.streamlock.net/Retemia/Retemia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kCJ621Q.png"/> |
-| 252 | Rete Oro Tv | [>](https://5926fc9c7c5b2.streamlock.net/9094/9094/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rkN64Gb.png"/> |
-| 253 | Rete Sole (Lazio) | [>](http://5c389faa13be3.streamlock.net:1935/8056/8056/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ajaa5pk.png"/> |
-| 254 | Rete Sole (Umbria) | [>](http://5c389faa13be3.streamlock.net:1935/8058/8058/chunklist_w696604988.m3u8) | <img height="20" src="https://i.imgur.com/u0ezKgE.png"/> |
-| 255 | Rete Tv Italia | [>](https://57068da1deb21.streamlock.net/retetvitalia/retetvitalia/chunklist_w992954157.m3u8) | <img height="20" src="https://i.imgur.com/lXGWoV9.png"/> |
-| 256 | Rete Veneta | [>](http://wms.shared.streamshow.it/reteveneta/reteveneta/chunklist_w1047580983.m3u8) | <img height="20" src="https://i.imgur.com/cInhQFp.png"/> |
-| 257 | Rossini Tv | [>](https://5cbd3bc28341f.streamlock.net:444/rossinitv_live/944A-63A6-9EB8-4492/playlist.m3u8) | <img height="20" src="https://i.imgur.com/K0Em0nx.jpg"/> |
-| 258 | Rtc Targato Napoli | [>](https://eu1.servers10.com:8081/8014/index.m3u8) | <img height="20" src="https://i.imgur.com/Jsep7uM.png"/> |
-| 259 | Rtp Tv | [>](http://flash2.xdevel.com/rtptv/rtptv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I1hYI0C.png"/> |
-| 260 | Rttr | [>](https://5f204aff97bee.streamlock.net/RTTRlive/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z7xMArA.png"/> |
-| 261 | Rtv 38 Toscana | [>](http://845d8509d2cb4f249dd0b2ae5755b6c2.msvdn.net/live/S12268608/CXHH7K39hg9K/playlist.m3u8) | <img height="20" src="https://i.imgur.com/xqlhJqK.png"/> |
-| 262 | Rtv Calabria | [>](https://59d7d6f47d7fc.streamlock.net/reggiotv/reggiotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ytwyx8D.png"/> |
-| 263 | Rtv San Marino Sat | [>](https://d2hrvno5bw6tg2.cloudfront.net/smrtv-ch01/_definst_/smil:ch-01.smil/chunklist_b1692000_slita.m3u8) | <img height="20" src="https://i.imgur.com/EsjYgQ1.jpg"/> |
-| 264 | SL 48 Tv | [>](http://media.velcom.it:1935/sl48/sl48/chunklist_w751971098.m3u8) | <img height="20" src="https://i.imgur.com/b58oouu.jpg"/> |
-| 265 | ST Europe Channel | [>](https://5f22d76e220e1.streamlock.net/steuropetv/steuropetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/T7kyY2p.png"/> |
-| 266 | Sardegna 1 | [>](https://59d8c0cee6f3d.streamlock.net/sardegnauno/sardegnauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qRRGn1e.png"/> |
-| 267 | Set Tv Cilento  | [>](https://stream1.aswifi.it/settv/live/index.m3u8) | <img height="20" src="https://i.imgur.com/qN5D1jD.png"/> |
-| 268 | Sicilia Media | [>](http://live.streamcaster.net:1935/siciliamediatv_live/siciliamedia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oQwo4AP.png"/> |
-| 269 | Sicilia Tv | [>](https://5f22d76e220e1.streamlock.net/SiciliaTV/SiciliaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I5FoThW.png"/> |
-| 270 | Sienatv | [>](https://flash8.xdevel.com/sienatv/sienatv/master.m3u8) | <img height="20" src="https://i.imgur.com/gcysky4.png"/> |
-| 271 | Siracusa Live Tv  | [>](https://5db313b643fd8.streamlock.net/SRLIVE_1/SRLIVE_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oyPkDnz.jpg"/> |
-| 272 | Sophia Tv | [>](https://www.onairport.live/sophiatv-it-live/livestream_low/chunklist_w217998957.m3u8) | <img height="20" src="https://i.imgur.com/fiLNK3b.jpg"/> |
-| 273 | Stiletv | [>](http://convision2.convergenze.it/hls-live/livepkgr/_definst_/liveevent/livestream1.m3u8) | <img height="20" src="https://i.imgur.com/v5Grhff.jpg"/> |
-| 274 | Studio 100 | [>](http://wms.shared.streamshow.it:1935/studio100ta/studio100ta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z84qFXd.png"/> |
-| 275 | Super J Tv | [>](http://uk4.streamingpulse.com:1935/SuperJtv/SuperJtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/5oy5Nuu.png"/> |
-| 276 | Super Six | [>](https://5db313b643fd8.streamlock.net/SUPERSIXLombardia/SUPERSIXLombardia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rv3RPMp.png"/> |
-| 277 | Supertv | [>](http://wms.shared.streamshow.it:1935/supertv/supertv/live.m3u8) | <img height="20" src="https://i.imgur.com/7gUZcEh.png"/> |
-| 278 | T.R.L Tele Radio Leo | [>](https://5db313b643fd8.streamlock.net/TRL/TRL/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qAagkJT.png"/> |
-| 279 | T.S.E. Uno (Tele Scout Europa) | [>](http://stream.mariatvcdn.com/tse/bd5a2cb40637623177295aed22db25f9.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OA0PRsb.png"/> |
-| 280 | T9 | [>](https://5f11919dca3bd.streamlock.net/t9/t9/chunklist_w1829149389.m3u8) | <img height="20" src="https://i.imgur.com/vlJaxJl.png"/> |
-| 281 | TRC Santeramo | [>](https://59d7d6f47d7fc.streamlock.net/trc/trc/playlist.m3u8) | <img height="20" src="https://i.imgur.com/VbYdS8P.jpg"/> |
-| 282 | TSD Tv Arezzo(Tele San Domenico) | [>](https://stream.mariatvcdn.com/tsd/7c59373bfdb38201b9215ff86f0ce6af.sdp/chunks.m3u8) | <img height="20" src="https://i.imgur.com/WQ8eQXc.png"/> |
-| 283 | TVL (TV Libera Pistoia) | [>](http://live.mariatvcdn.com/mariatvcdn/70564e1c6884c007c76f0c128d679eed.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/07geF0L.png"/> |
-| 284 | Tcf Tv | [>](http://live.sloode.com:1935/tcf_live/telecineforum/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fiylFs2.jpg"/> |
-| 285 | Tci | [>](https://player-api.new.livestream.com/accounts/27460990/events/8287184/broadcasts/223071659.secure.m3u8) | <img height="20" src="https://i.imgur.com/lCZTaKs.jpg"/> |
-| 286 | Teatro Tv | [>](https://m.iostream.it/hls/teatrotv/teatrotv.m3u8) | <img height="20" src="https://i.imgur.com/UsvffQL.png"/> |
-| 287 | Tele A | [>](http://82.62.190.94/hls/telea/video.m3u8) | <img height="20" src="https://i.imgur.com/l7Za9KH.jpg"/> |
-| 288 | Tele Abruzzo Tv | [>](http://uk4.streamingpulse.com:1935/TeleabruzzoTV/TeleabruzzoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/koB8J4b.jpg"/> |
-| 289 | Tele Acras | [>](https://5cbd3bc28341f.streamlock.net:444/teleacras/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/90Lsv8q.png"/> |
-| 290 | Tele Arena | [>](https://5e73cf528f404.streamlock.net/TeleArena/TeleArena.stream/chunklist_w188795637.m3u8) | <img height="20" src="https://i.imgur.com/9hsoWMO.png"/> |
-| 291 | Tele Argento/Magic Tv | [>](http://163.172.88.73:1935/magic_web/site/chunklist_w1342104039.m3u8) | <img height="20" src="https://i.imgur.com/gseTf4W.jpg"/> |
-| 292 | Tele Bari | [>](http://fl1.mediastreaming.it:1935/telebari/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HYSz4rx.png"/> |
-| 293 | Tele Bari | [>](https://w1.mediastreaming.it/telebari/livestream/chunklist_w509152460.m3u8) | <img height="20" src="https://i.imgur.com/xO1oEXu.png"/> |
-| 294 | Tele Belluno | [>](https://live.mariatvcdn.com/telebelluno/a3b80388da9801906adf885282e73bc3.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/YiM2Z7E.png"/> |
-| 295 | Tele Blu | [>](https://58d921499d3d3.streamlock.net/Teleblu/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NWMTlry.jpg"/> |
-| 296 | Tele Boario | [>](http://flash7.streaming.xdevel.com/teleboario/teleboario/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LlLD3L6.png"/> |
-| 297 | Tele Bruzzano | [>](https://player.ilariochiera.it/fileadmin/hls/Telebruzzano/telebruzzano_mediachunks.m3u8) | <img height="20" src="https://i.imgur.com/7TWbCDt.jpg"/> |
-| 298 | Tele Chiara | [>](http://fms.tvavicenza.it:1935/telechiara/diretta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Q5XpnXR.png"/> |
-| 299 | Tele Citta' Padova | [>](rtmp://stream.telepadova.com/live/tv1.flv) | <img height="20" src="https://i.imgur.com/xvVgEaA.jpg"/> |
-| 300 | Tele Citta' | [>](http://213.187.12.18/live/tv1.m3u8) | <img height="20" src="https://i.imgur.com/yWwLLOm.png"/> |
-| 301 | Tele Club Italia | [>](https://www.theclubfactory.com/streaming/index.m3u8) | <img height="20" src="https://i.imgur.com/WxkOgg0.png"/> |
-| 302 | Tele Clusone Bergamo | [>](https://media.streambrothers.com:1936/8546/8546/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dVDY1ng.png"/> |
-| 303 | Tele Color Lombardia | [>](http://cdn.mainstreaming.tv/live/324149/hlbAWtl/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hUA29XI.jpg"/> |
-| 304 | Tele Cupole | [>](http://live.livevideosolution.it/telecupole/dd6d85e5b7452f7b85a099509292b421.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ZmUI9zb.png"/> |
-| 305 | Tele Estense | [>](https://5e73cf528f404.streamlock.net/TeleEstense/livestream/chunklist_w530758405.m3u8) | <img height="20" src="https://i.imgur.com/X7i7DWo.png"/> |
-| 306 | Tele Foggia | [>](http://wms.shared.streamshow.it/telefoggia/mp4:telefoggia/chunklist_w386788975.m3u8) | <img height="20" src="https://i.imgur.com/M7tqBu9.jpg"/> |
-| 307 | Tele Friuli | [>](https://streamtechglobal.akamaized.net/hls/live/2024685/telefriuli/Group01/2024685-telefriuli/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/AoQxZxD.png"/> |
-| 308 | Tele Gela | [>](http://live.sloode.com:1935/qdg_live/AF74-FF2C-7350-41F2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sjrxbgP.png"/> |
-| 309 | Tele Genova | [>](https://5db313b643fd8.streamlock.net/Telegenova/Telegenova/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BXvPBKb.png"/> |
-| 310 | Tele Granda | [>](http://live.sloode.com:1935/telegranda_live/C2AD-0664-DC75-4744/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mdPc8cX.jpg"/> |
-| 311 | Tele Ischia | [>](https://eu1.servers10.com:8081/8130/index.m3u8) | <img height="20" src="https://i.imgur.com/vihHVQn.jpg"/> |
-| 312 | Tele Jonio | [>](http://59d7d6f47d7fc.streamlock.net/telejonio/telejonio/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qJeDV8R.png"/> |
-| 313 | Tele Lazio Nord | [>](http://tln.srfms.com:1935/TLN/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gZEojVW.png"/> |
-| 314 | Tele Liberta' HD | [>](https://player-api.new.livestream.com/accounts/17114188/events/4902226/broadcasts/223072237.secure.m3u8) | <img height="20" src="https://i.imgur.com/XzAB5k7.jpg"/> |
-| 315 | Tele Liguria Sud | [>](https://live.teleliguriasud.it/hls/tls/index.m3u8) | <img height="20" src="https://i.imgur.com/BeLAYJ6.jpg"/> |
-| 316 | Tele Mantova | [>](https://5ce9406b73c33.streamlock.net/TeleMantova/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bkSPcs4.png"/> |
-| 317 | Tele Mia Extra | [>](https://player.ilariochiera.it/fileadmin/hls/TelemiaExtra/stream.m3u8) | <img height="20" src="https://i.imgur.com/upzBG32.png"/> |
-| 318 | Tele Mia | [>](http://wms.shared.streamshow.it:80/telemia/telemia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/SdXpCwL.png"/> |
-| 319 | Tele Mistretta Life e Family | [>](https://stream.mariatvcdn.com/telemistrettalive2/ddbcd59a192d6f92336991e344fa1821.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/y2LLwiy.png"/> |
-| 320 | Tele Mistretta Radio | [>](https://stream.mariatvcdn.com/telemistrettaradio/900bfcc0f9012ea272584fd5ff5281b8.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/d7O7Uqa.png"/> |
-| 321 | Tele Mistretta | [>](https://live.mariatvcdn.com/telemistretta/8fbcd205ada81b295ee6c211c3a80dde.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OJ3zUS0.png"/> |
-| 322 | Tele Molise | [>](http://185.202.128.1:1935/TelemoliseStream/telemoliseTV.stream_tlm/chunklist_w1170267390.m3u8) | <img height="20" src="https://i.imgur.com/u5VD0x9.png"/> |
-| 323 | Tele Monteneve 3 | [>](http://wms.shared.streamshow.it/telemonteneve3/telemonteneve3/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LJhQApn.jpg"/> |
-| 324 | Tele Norba (TG Norba 24 )| [>](https://flash2.xdevel.com/tgnorba_24/tgnorba_24_source.stream/manifest.mpd) | <img height="20" src="https://i.imgur.com/9MhrrJK.png"/> |
-| 325 | Tele Nord Est | [>](https://59d7d6f47d7fc.streamlock.net/telenord/telenord/chunklist_w2111676469.m3u8) | <img height="20" src="https://i.imgur.com/TakoSUX.png"/> |
-| 326 | Tele Nord Genova | [>](https://5db313b643fd8.streamlock.net/Telenord/Telenord/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gQWB9Gx.png"/> |
-| 327 | Tele Nostra | [>](https://meridelive-lh.akamaihd.net/i/ottop_1@118465/index_1_av-p.m3u8?sd=10&amp;rebase=on) | <img height="20" src="https://i.imgur.com/FACahKZ.png"/> |
-| 328 | Tele Occidente | [>](http://ciaoitalystream.ddns.net/live/webTELEOCCIDENTEweb/montelepre@palermo/2.m3u8) | <img height="20" src="https://i.imgur.com/3aOiWKa.png"/> |
-| 329 | Tele Oltre | [>](http://1se1.troydesign.eu/np_teleoltre/_definst_/channel1_np_teleoltre/playlist.m3u8?ext=.m3u8) | <img height="20" src="https://i.imgur.com/PxtJAxs.png"/> |
-| 330 | Tele One | [>](http://live.streamcaster.net:1935/mediaone_live/teleone/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hTDDVOQ.png"/> |
-| 331 | Tele Pace 1 | [>](https://live.mariatvcdn.com/teleradiopace1/efcc8fc46cab26315ce3f5845d76008f.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/ut0Hg8o.png"/> |
-| 332 | Tele Pace 2 | [>](https://live.mariatvcdn.com/teleradiopace2/254c9b5c52a73a94ef0f6169cbd05dc2.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/RqrPraO.png"/> |
-| 333 | Tele Pace 3 | [>](https://live.mariatvcdn.com/teleradiopace3/d2274c22e9ee09eb2eda01ed0496f8f5.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/gLsE3mX.png"/> |
-| 334 | Tele Pace 4 | [>](https://live.mariatvcdn.com/teleradiopace4/13d74f2cfe921bfbc262697203d47d8f.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/tEQvgpz.png"/> |
-| 335 | Tele Pace News | [>](https://live.mariatvcdn.com/teleradiopace6/d289fe76f16ad32afec471ea1b941583.sdp/index.m3u8) | <img height="20" src="https://i.imgur.com/AxmgoMT.png"/> |
-| 336 | Tele Pace Roma | [>](https://live.mariatvcdn.com/mariatvpoint/d36592901d5429dd7f9ec1e7bbeda8c2.sdp/index.m3u8) | <img height="20" src="https://i.imgur.com/54oi0cg.png"/> |
-| 337 | Tele Pace Trento | [>](https://5a1178b42cc03.streamlock.net/telepacetrento/telepacetrento/playlist.m3u8) | <img height="20" src="https://i.imgur.com/o5sQCpF.png"/> |
-| 338 | Tele Pace Verona | [>](https://live.mariatvcdn.com/TelepaceVerona/a9027aba28cf4b54d10aedc38b0df192.sdp/index.m3u8) | <img height="20" src="https://i.imgur.com/su2ipkb.png"/> |
-| 339 | Tele Pavia | [>](http://wms.shared.streamshow.it:1935/telepavia/telepavia/live.m3u8) | <img height="20" src="https://i.imgur.com/YVodo4T.png"/> |
-| 340 | Tele Pegaso | [>](https://flash2.xdevel.com/telepegasocanale812/telepegasocanale812/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FQkM8Vd.png"/> |
-| 341 | Tele Piadena  | [>](https://stream3.xdevel.com/video0s975441-151/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/VqaPuQN.png"/> |
-| 342 | Tele Pordenone | [>](https://video.wifi4all.it/telepn/telepn.m3u8) | <img height="20" src="https://i.imgur.com/dbYwXwg.png"/> |
-| 343 | Tele Prima | [>](http://live.sloode.com:1935/teleprima/live/chunklist_w268781554.m3u8) | <img height="20" src="https://i.imgur.com/WLziQCV.png"/> |
-| 344 | Tele Quattro Trieste | [>](http://wms.shared.streamshow.it/telequattro/telequattro/chunklist_w1388066579.m3u8) | <img height="20" src="https://i.imgur.com/MFxQxve.png"/> |
-| 345 | Tele Radio Ercolano | [>](https://eu1.servers10.com:8081/8012/index.m3u8) | <img height="20" src="https://i.imgur.com/YPuoy8N.jpg"/> |																																												   
-| 346 | Tele Radio Orte | [>](https://flash2.xdevel.com/ortetv/ortetv/index.m3u8) | <img height="20" src="https://i.imgur.com/uX2uxvN.png"/> |
-| 347 | Tele Radio Sciacca | [>](http://5cbd3bc28341f.streamlock.net:1935/trs_live/teleradiosciacca-tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/suhz5mE.png"/> |
-| 348 | Tele Radio Studio 5 | [>](http://mars.az-streamingserver.com:1935/7444/7444/chunklist_w1479892021.m3u8) | <img height="20" src="https://i.imgur.com/lPRjSor.jpg"/> |
-| 349 | Tele Rama | [>](https://58d921499d3d3.streamlock.net/TeleRama/livestream/chunklist_w1747460348.m3u8) | <img height="20" src="https://i.imgur.com/enfqUlI.jpg"/> |
-| 350 | Tele Roma 1 | [>](https://flash2.xdevel.com/teleromauno/teleromauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3t7JWrf.png"/> |
-| 351 | Tele Romagna 24 | [>](http://livetr.teleromagna.it/mia/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Bpml478.png"/> |
-| 352 | Tele Romagna Lifestyle | [>](http://livetr.teleromagna.it/lifestyle/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gup84Sb.png"/> |
-| 353 | Tele Romagna Mia | [>](http://livetr.teleromagna.it/news/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/IdHPiQz.png"/> |
-| 354 | Tele Romagna | [>](http://livetr.teleromagna.it/teleromagna/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4jWadI8.png"/> |
-| 355 | Tele Sirio | [>](https://www.telesirio.it/live/stream.m3u8) | <img height="20" src="https://i.imgur.com/mDN6QX1.png"/> |
-| 356 | Tele Spazio Messina | [>](http://smart.telespazioplay.com:8080/play/stream.m3u8) | <img height="20" src="https://i.imgur.com/Io5w6lT.png"/> |
-| 357 | Tele Star 1 | [>](http://193.34.109.10:8090/) | <img height="20" src="https://i.imgur.com/UZQjEsd.png"/> |
-| 358 | Tele Sud Puglia | [>](https://webtv.pugliaservice.it:1936/telesud-webtv/telesud-webtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fqTLtvs.png"/> |
-| 359 | Tele Sveva News 24 | [>](https://dc1.telesveva.erefresh.it:4443/news24.mp4) | <img height="20" src="https://i.imgur.com/4HlRpf4.jpg"/> |
-| 360 | Tele Tebe | [>](https://5c389faa13be3.streamlock.net:9553/calabriasat/calabriasat/playlist.m3u8) | <img height="20" src="https://i.imgur.com/YirYT4J.png"/> |
-| 361 | Tele Terni | [>](https://diretta.teleterni.it/live/stream_src.m3u8) | <img height="20" src="https://i.imgur.com/lslSS3a.jpg"/> |
-| 362 | Tele Ticino | [>](https://livestream.gruppocdt.ch/hls/teleticino.m3u8) | <img height="20" src="https://i.imgur.com/izfB7u1.png"/> |
-| 363 | Tele Tricolore | [>](https://59d7d6f47d7fc.streamlock.net/rs2/rs2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/A2XouAd.png"/> |
-| 364 | Tele Tutto 2 | [>](https://600f07e114306.streamlock.net/TT2_TELETUTTO/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mxXbMaw.png"/> |
-| 365 | Tele Tutto 24 | [>](https://600f07e114306.streamlock.net/TT24_TELETUTTO/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/weKWQgx.png"/> |
-| 366 | Tele Tutto | [>](https://600f07e114306.streamlock.net/TT_TELETUTTO/smil:TT.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sZxMP7g.png"/> |
-| 367 | Tele Venezia | [>](https://59d8c0cee6f3d.streamlock.net/televenezia/televenezia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/SavGpCE.jpg"/> |
-| 368 | Tele Video Agrigento (T.V.A.) | [>](https://59d7d6f47d7fc.streamlock.net/tva/tva/chunklist_w2057719642.m3u8) | <img height="20" src="https://i.imgur.com/AaPr63E.png"/> |
-| 369 | TeleMajg | [>](https://59d7d6f47d7fc.streamlock.net/telemajg/telemajg/chunklist_w656612441.m3u8) | <img height="20" src="https://i.imgur.com/9tefonp.jpg"/> |
-| 370 | Telesud Trapani | [>](https://5cbd3bc28341f.streamlock.net:444/telesud/_definst_/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/tpZvU1P.png"/> |
-| 371 | Teleuniverso | [>](https://media.velcom.it:19360/teleuniverso/teleuniverso.m3u8) | <img height="20" src="https://i.imgur.com/u8E9wBb.png"/> |
-| 372 | Televallo Trapani | [>](https://5cbd3bc28341f.streamlock.net:444/televallo/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/P6zuiRH.png"/> |
-| 373 | Tevere Tv | [>](https://5926fc9c7c5b2.streamlock.net/9098/9098/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ghBX2Hn.png"/> |
-| 374 | Touring Tv | [>](https://flash2.xdevel.com/radiotouring10496/radiotouring10496_aac/playlist.m3u8) | <img height="20" src="https://i.imgur.com/E2Feao5.jpg"/> |
-| 375 | Trentino Tv | [>](https://5e73cf528f404.streamlock.net/TrentinoTV/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ROKOCR2.png"/> |
-| 376 | Tris News | [>](https://5db313b643fd8.streamlock.net/WLTV/WLTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/zasGDNl.jpg"/> |
-| 377 | Tris Siracusa | [>](https://5db313b643fd8.streamlock.net/Tris/Tris/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dZgKD3j.jpg"/> |
-| 378 | Trm H24 | [>](http://w1.streamingmedia.it:1935/trmh24/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/eWV9yII.png"/> |
-| 379 | Tsn Lecco | [>](http://59d8c0cee6f3d.streamlock.net/tsn2/tsn2_mobile/playlist.m3u8) | <img height="20" src="https://i.imgur.com/vlyaN3U.jpg"/> |
-| 380 | Tsn Tele Sondrio News | [>](http://wms.shared.streamshow.it/tsn/tsn_mobile/playlist.m3u8) | <img height="20" src="https://i.imgur.com/24Anl5o.png"/> |
-| 381 | Tua Channel | [>](https://media2021.rtvweb.com/promovideo_web/tuachannel/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BDdQvtS.png"/> |
-| 382 | Tuscia Sabina 2000Tv | [>](http://ts2000tv.streaming.nextware.it:8081/ts2000tv/ts2000tv/chunks.m3u8) | <img height="20" src="https://i.imgur.com/Tq5nEAy.png"/> |
-| 383 | Tv 6 | [>](http://185.202.128.1:1935/Tv6Stream/tv6TV.stream_tlm/chunklist_w16775241.m3u8) | <img height="20" src="https://i.imgur.com/bJ2e604.png"/> |
-| 384 | Tv Campane 1 | [>](https://eu1.servers10.com:8081/8032/index.m3u8) | <img height="20" src="https://i.imgur.com/UrHKovD.jpg"/> |
-| 385 | Tv Campania Streaming | [>](https://eu1.servers10.com:8081/8020/index.m3u8) | <img height="20" src="https://i.imgur.com/5Ly6LyC.png"/> |
-| 386 | Tv Luna Napoli  | [>](https://streamlive.arcapuglia.it:8080/live/teleluna/index.m3u8) | <img height="20" src="https://i.imgur.com/jxhuoyE.png"/> |
-| 387 | Tv Prato | [>](https://live.mariatvcdn.com/tvprato/2db0dd5674586686a867ec52c3aa8e06.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/zDeVpZd.png"/> |
-| 388 | Tv Qui Modena | [>](https://59d7d6f47d7fc.streamlock.net/tvqui/tvqui/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4bOYlfg.png"/> |
-| 389 | Tv Uno | [>](http://ftp.tiscali.it/francescovernata/TVUNO/monoscopioTvUNOint-1.wmv) | <img height="20" src="https://i.imgur.com/OtCwYsh.jpg"/> |
-| 390 | Tv7 Azzurra | [>](http://217.61.26.46:8080/hls/azzurra.m3u8) | <img height="20" src="https://i.imgur.com/yYvGWHL.png"/> |
-| 391 | Tv7 News | [>](http://217.61.26.46:8080/hls/news.m3u8) | <img height="20" src="https://i.imgur.com/rlMEE1j.png"/> |
-| 392 | Tv7 Triveneta | [>](http://217.61.26.46:8080/hls/triveneta.m3u8) | <img height="20" src="https://i.imgur.com/O2NF7jJ.jpg"/> |
-| 393 | Tva Agrigento | [>](https://59d7d6f47d7fc.streamlock.net/tva/tva/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6dxp79F.png"/> |
-| 394 | Tva Vicenza | [>](http://fms.tvavicenza.it:1935/live/diretta_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FtFuPCC.png"/> |
-| 395 | Tvr Xenon | [>](https://cloudtv.azotosolutions.com:9553/tvrxenonlive/tvrxenonlive/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kLzW1Pf.jpg"/> |
-| 396 | Tvrs Tv | [>](https://59d7d6f47d7fc.streamlock.net/tvrs/tvrs/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6p7hTmY.jpg"/> |
-| 397 | Umbria TV  | [>](https://umbriatv.stream.rubidia.it:8083/live/umbriatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kccGe02.png"/> |
-| 398 | Uninettuno University Tv  | [>](https://stream6-rai-it.akamaized.net/live/uninettuno/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/awnuxMY.png"/> |
-| 399 | Vera Tv | [>](http://wms.shared.streamshow.it/veratv/veratv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/djMvkvN.png"/> |
-| 400 | Video 33 | [>](http://livestream.goinfo.it/V33Live/v33ros/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Wp24htV.jpg"/> |
-| 401 | Video Brescia | [>](http://wms.shared.streamshow.it/videobrescia/videobrescia/hasbahca.m3u8) | <img height="20" src="https://i.imgur.com/9Fw2wBT.png"/> |
-| 402 | Video Mediterraneo | [>](http://stream.ets-sistemi.it:1935/live.rvm/rvmtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hJHC3uQ.png"/> |
-| 403 | Video Nola | [>](http://stream1.aswifi.it/videonola/live/index.m3u8) | <img height="20" src="https://i.imgur.com/M5z5UoD.jpg"/> |
-| 404 | Video Star | [>](https://5cbd3bc28341f.streamlock.net:444/videostar_live/_definst_/videostar/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1ddJVZ7.jpg"/> |
-| 405 | Videolina | [>](http://livestreaming.videolina.it/live/Videolina/chunklist_w488279894.m3u8) | <img height="20" src="https://i.imgur.com/bnDZJwd.gif"/> |
-| 406 | Videostar Tv Lombardia | [>](http://dreamsiteradiocpvideo.com:1935/vds/vds/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ecpPFZL.jpg"/> |
-| 407 | Vuemme Tv | [>](https://5db313b643fd8.streamlock.net/Vuemme/Vuemme/chunklist_w1853927005.m3u8) | <img height="20" src="https://i.imgur.com/x5A0xU6.png"/> |
-| 408 | Well Tv | [>](https://59d7d6f47d7fc.streamlock.net/welltv/welltv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Kqgz4Na.png"/> |
-| 409 | Yvii Tv | [>](rtmp://yviistreamer.kernel.online:1935/live/yviitv) | <img height="20" src="https://i.imgur.com/yP5AvDo.png"/> |
-| 410 | Zerouno Tv News | [>](https://5db313b643fd8.streamlock.net/ZerounoTVEventi/ZerounoTVEventi/playlist.m3u8) | <img height="20" src="https://i.imgur.com/vxRzyjE.png"/> |

--- a/italy.md
+++ b/italy.md
@@ -348,6 +348,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Video Star | [>](https://5cbd3bc28341f.streamlock.net:444/videostar_live/_definst_/videostar/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1ddJVZ7.jpg"/> |
 | 0   | Videolina | [>](http://livestreaming.videolina.it/live/Videolina/chunklist_w488279894.m3u8) | <img height="20" src="https://i.imgur.com/bnDZJwd.gif"/> |
 | 0   | Videostar Tv Lombardia | [>](http://dreamsiteradiocpvideo.com:1935/vds/vds/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ecpPFZL.jpg"/> |
+| 0   | Vintage Radio Tv | [>](https://stream4.xdevel.com/video0s975967-804/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/n3LtBNT.jpg"/> |
 | 0   | Vuemme Tv | [>](https://5db313b643fd8.streamlock.net/Vuemme/Vuemme/chunklist_w1853927005.m3u8) | <img height="20" src="https://i.imgur.com/x5A0xU6.png"/> |
 | 0   | Well Tv | [>](https://59d7d6f47d7fc.streamlock.net/welltv/welltv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Kqgz4Na.png"/> |
 | 0   | Yvii Tv | [>](rtmp://yviistreamer.kernel.online:1935/live/yviitv) | <img height="20" src="https://i.imgur.com/yP5AvDo.png"/> |

--- a/italy.md
+++ b/italy.md
@@ -111,6 +111,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Castrovillari Tv | [>](rtmp://msh0062.stream.seeweb.it:1935/live/stream00.sdp) | <img height="20" src="https://i.imgur.com/V0kjYNG.png"/> |
 | 0   | Cilento Channel | [>](https://streaming.dimind.it/live/cilentocnn/index.m3u8) | <img height="20" src="https://i.imgur.com/4k9Su8j.png"/> |
 | 0   | Cremona 1 | [>](https://59d8c0cee6f3d.streamlock.net/cremona1/cremona1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a5d0F01.jpg"/> |
+| 0   | Cusano Italia Tv | [>](https://router.xdevel.com/video0s975363-69/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9F1sVjZ.png"/> |
 | 0   | Di.Tv 90 | [>](http://163.172.88.73:1935/di_tv_90/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ul0o7zv.png"/> |
 | 0   | Digital Tv7 Benevento | [>](http://streaming.senecadot.com/live/flv:tv7.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NaQkklP.png"/> |
 | 0   | E'live Brescia Tv | [>](https://59d7d6f47d7fc.streamlock.net/elivebresciatv/elivebresciatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bZ3B7pi.png"/> |
@@ -127,12 +128,12 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | GRP Televisione | [>](https://5cbd3bc28341f.streamlock.net:444/grp/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1zNPpVE.png"/> |
 | 0   | Giornale Radio Tv | [>](https://5db313b643fd8.streamlock.net:443/GiornaleRadioTelevision/GiornaleRadioTelevision/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TMtvCLL.jpg"/> |
 | 0   | Gold 78 HD  | [>](http://stream2.xdevel.com/video1s86-22/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/2UHu1ye.png"/> |
-| 0   | Gold Tv  | [>](http://151.0.207.99:1935/GoldTV/GOLD_17/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3rVi4kD.png"/> |
+| 0   | Gold Tv  | [>](https://5f11919dca3bd.streamlock.net/GoldTV/GOLD_17/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3rVi4kD.png"/> |
 | 0   | HUB Tv | [>](https://5c483b9d1019c.streamlock.net/8004/8004/playlist.m3u8) | <img height="20" src="https://i.imgur.com/46GTBEW.png"/> |
 | 0   | Icaro Tv Rimini | [>](https://59d7d6f47d7fc.streamlock.net/icarotv/icarotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z05VSSN.png"/> |
 | 0   | Idea Plus | [>](https://eu1.servers10.com:8081/8044/index.m3u8) | <img height="20" src="https://i.imgur.com/2edmxYF.png"/> |
 | 0   | Italia 2 | [>](https://59d7d6f47d7fc.streamlock.net/italia2/italia2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ISbxfY0.png"/> |
-| 0   | Italia 7 | [>](http://151.0.207.99:1935/italia7/italia7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/YBXkY4w.png"/> |
+| 0   | Italia 7 | [>](https://5f11919dca3bd.streamlock.net/italia7/italia7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/YBXkY4w.png"/> |
 | 0   | Iunior Tv | [>](https://5f22d76e220e1.streamlock.net/iuniortv/iuniortv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9jeNlLE.png"/> |
 | 0   | L'Altro Corriere Tv  | [>](https://stream.ets-sistemi.it/live.laltrocorrieretv/laltrocorrieretv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dgj79J3.png"/> |
 | 0   | La Tua Tv | [>](https://wms2.zivoli.it/latuatv/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Nc3I0cS.png"/> |
@@ -140,7 +141,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | LaC News 24 | [>](https://cdn.mainstreaming.tv/live/100532/HVvPMzy/playlist.m3u8?rnd=861954) | <img height="20" src="https://i.imgur.com/02vCECa.png"/> |
 | 0   | LaC Tv Calabria | [>](http://streamcdnb9-f5842579ff984c1c98d63b8d789673eb.msvdn.net/live/100197/SOrBDPy/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2Ef6crS.png"/> |
 | 0   | Lab Tv | [>](http://live.sloode.com:1935/labtv_live/labtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OpRS6Fl.png"/> |
-| 0   | Lazio Tv | [>](http://151.0.207.99:1935/live/LAZIOTV12/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6gbWHvP.jpg"/> |
+| 0   | Lazio Tv | [>](https://5f11919dca3bd.streamlock.net/live/LAZIOTV12/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6gbWHvP.jpg"/> |
 | 0   | Le Cronache Lucane Tv | [>](http://stucazz.com:8888/hls/cronache.m3u8) | <img height="20" src="https://i.imgur.com/EBY3IZL.jpg"/> |
 | 0   | Lira Tv | [>](https://5e06222f4d978.streamlock.net/liratv/liratv1500/playlist.m3u8) | <img height="20" src="https://i.imgur.com/S0ReVEo.png"/> |
 | 0   | Lombardia Tv | [>](https://5db313b643fd8.streamlock.net/LOMBARDIATV/LOMBARDIATV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/aksVy9f.jpg"/> |
@@ -202,6 +203,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Rete Sole (Umbria) | [>](http://5c389faa13be3.streamlock.net:1935/8058/8058/playlist.m3u8) | <img height="20" src="https://i.imgur.com/u0ezKgE.png"/> |
 | 0   | Rete Tv Italia | [>](https://57068da1deb21.streamlock.net/retetvitalia/retetvitalia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lXGWoV9.png"/> |
 | 0   | Rete Veneta | [>](http://wms.shared.streamshow.it/reteveneta/reteveneta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/cInhQFp.png"/> |
+| 0   | Roma Ch 71 | [>](https://5f11919dca3bd.streamlock.net/ROMACH71/CH71/playlist.m3u8) | <img height="20" src="https://i.imgur.com/UVgXu9L.png"/> |
 | 0   | Rossini Tv | [>](https://5cbd3bc28341f.streamlock.net:444/rossinitv_live/944A-63A6-9EB8-4492/playlist.m3u8) | <img height="20" src="https://i.imgur.com/K0Em0nx.jpg"/> |
 | 0   | Rtc Targato Napoli | [>](https://eu1.servers10.com:8081/8014/index.m3u8) | <img height="20" src="https://i.imgur.com/Jsep7uM.png"/> |
 | 0   | Rtp Tv | [>](http://flash2.xdevel.com/rtptv/rtptv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I1hYI0C.png"/> |

--- a/italy.md
+++ b/italy.md
@@ -398,6 +398,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 4550 | Film d'azione – Rakuten TV | [>](https://rakuten-actionmovies-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KDmDQM6.jpg"/> |
 | 5000 | Film Top – Rakuten TV | [>](https://rakuten-topfree-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
 | 5005 | Classico – Rakuten TV | [>](https://rakuten-classico-1-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
+| 5008 | Thriller – Rakuten TV | [>](https://rakuten-thriller-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
 | 5009 | Romance – Rakuten TV | [>](https://rakuten-romance-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
 
 <h2>Invalid</h2>

--- a/italy.md
+++ b/italy.md
@@ -87,8 +87,8 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Antenna Sud 85 | [>](https://streamlive85.arcapuglia.it:8080/live/canale85/index.m3u8) | <img height="20" src="https://i.imgur.com/0JM7Jw0.png"/> |
 | 0   | Antenna Sud 90 | [>](https://streamlivesud.arcapuglia.it:8080/live/teleonda/index.m3u8) | <img height="20" src="https://i.imgur.com/jsGagGp.png"/> |
 | 0   | Apulia Web Tv | [>](https://cp1.server89.com:19360/apuliawebtv/apuliawebtv.m3u8) | <img height="20" src="https://i.imgur.com/AnU4g2J.png"/> |
-| 0   | Aurora Arte | [>](https://59d7d6f47d7fc.streamlock.net/auroraarte/auroraarte/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/BoLZ5wG.png"/> |
-| 0   | Azzurra Tv Vco | [>](http://sb.top-ix.org:1935/avtvlive/streaming/chunklist_w1605488247.m3u8) | <img height="20" src="https://i.imgur.com/mSWw8uW.png"/> |
+| 0   | Aurora Arte | [>](https://59d7d6f47d7fc.streamlock.net/auroraarte/auroraarte/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BoLZ5wG.png"/> |
+| 0   | Azzurra Tv Vco | [>](https://sb.top-ix.org/avtvlive/streaming/playerlist.m3u8) | <img height="20" src="https://i.imgur.com/mSWw8uW.png"/> |
 | 0   | Basilicata 1 Tv | [>](http://77.68.40.210:8888/hls/basilicata1.m3u8) | <img height="20" src="https://i.imgur.com/VS6CQ88.png"/> |
 | 0   | Cafe Tv 24 | [>](http://srv3.meway.tv:1957/cafe/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KbcbxFw.png"/> |
 | 0   | Calabria Uno TV  | [>](https://5f22d76e220e1.streamlock.net/calabriaunotv/calabriaunotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2TK1GQ5.png"/> |
@@ -97,33 +97,33 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Canale 12 Sassari | [>](http://wifitv.tv/media/live/1001/video_850000.m3u8) | <img height="20" src="https://i.imgur.com/u6P2lTY.jpg"/> |
 | 0   | Canale 16 | [>](https://5f11919dca3bd.streamlock.net/Canale16/Canale16/playlist.m3u) | <img height="20" src="https://i.imgur.com/SPfgKHk.png"/> |
 | 0   | Canale 18 | [>](https://5f11919dca3bd.streamlock.net/Canale18/Canale18/playlist.m3u8) | <img height="20" src="https://i.imgur.com/PZBX4iy.png"/> |
-| 0   | Canale 2 | [>](https://59d7d6f47d7fc.streamlock.net/canale2/canale2/chunklist_w811855890.m3u8) | <img height="20" src="https://i.imgur.com/ETqDkS1.png"/> |
+| 0   | Canale 2 | [>](https://59d7d6f47d7fc.streamlock.net/canale2/canale2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ETqDkS1.png"/> |
 | 0   | Canale 21 Campania | [>](https://stream.mariatvcdn.com/canaleventuno/f5d2060b3682e0dfffd5b2f18e935ad3.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KVh8cOR.png"/> |
 | 0   | Canale 21 Lazio | [>](https://stream.mariatvcdn.com/canaleventunodue/61d14e72c90980498c9d7cee64fde847.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KVh8cOR.png"/> |
 | 0   | Canale 58 | [>](https://dotfvxkfj90ca.cloudfront.net/live/canale58_aac/master.m3u8) | <img height="20" src="https://i.imgur.com/RlFc74C.png"/> |
 | 0   | Canale 7 | [>](http://wms.shared.streamshow.it:80/canale7/canale7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9cuOLCn.png"/> |
 | 0   | Canale 74 Sicilia | [>](http://stream.ets-sistemi.it:1935/live.canale74/canale74tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/18JIVgu.png"/> |
-| 0   | Canale 8 | [>](https://59d8c0cee6f3d.streamlock.net/canale8/canale8/chunklist_w592700549.m3u8) | <img height="20" src="https://i.imgur.com/ElAS2WC.png"/> |
-| 0   | Canale Italia 83 | [>](http://ovp-live.akamaized.net/ac024_live/video1/chunklist.m3u8?accessToken=51c3544ac33a24b012ba69bf6349db78) | <img height="20" src="https://i.imgur.com/ZaenpJA.jpg"/> |
+| 0   | Canale 8 | [>](https://59d8c0cee6f3d.streamlock.net/canale8/canale8/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ElAS2WC.png"/> |
+| 0   | Canale Italia 83 | [>](https://ovp-live.akamaized.net/ac024_live/video1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ZaenpJA.jpg"/> |
 | 0   | Canale Uno Tivù | [>](https://eu1.servers10.com:8081/8096/index.m3u8) | <img height="20" src="https://i.imgur.com/hfqNw92.png"/> |
 | 0   | Carina Tv | [>](http://wms.shared.streamshow.it/carinatv/mp4:carinatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FMGcm6I.jpg"/> |
 | 0   | Casa del Sole Tv | [>](https://eu1.servers10.com:8081/8040/index.m3u8) | <img height="20" src="https://i.imgur.com/qPdGelu.png"/> |
 | 0   | Castrovillari Tv | [>](rtmp://msh0062.stream.seeweb.it:1935/live/stream00.sdp) | <img height="20" src="https://i.imgur.com/V0kjYNG.png"/> |
 | 0   | Cilento Channel | [>](https://streaming.dimind.it/live/cilentocnn/index.m3u8) | <img height="20" src="https://i.imgur.com/4k9Su8j.png"/> |
 | 0   | Cremona 1 | [>](https://59d8c0cee6f3d.streamlock.net/cremona1/cremona1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a5d0F01.jpg"/> |
-| 0   | Di.Tv 90 | [>](http://163.172.88.73:1935/di_tv_90/live/chunklist_w707472623.m3u8) | <img height="20" src="https://i.imgur.com/ul0o7zv.png"/> |
-| 0   | Digital Tv7 Benevento | [>](http://streaming.senecadot.com/live/flv:tv7.sdp/chunklist_w132253248.m3u8) | <img height="20" src="https://i.imgur.com/NaQkklP.png"/> |
-| 0   | E'live Brescia Tv | [>](https://59d7d6f47d7fc.streamlock.net/elivebresciatv/elivebresciatv/chunklist_w1234149773.m3u8) | <img height="20" src="https://i.imgur.com/bZ3B7pi.png"/> |
+| 0   | Di.Tv 90 | [>](http://163.172.88.73:1935/di_tv_90/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ul0o7zv.png"/> |
+| 0   | Digital Tv7 Benevento | [>](http://streaming.senecadot.com/live/flv:tv7.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NaQkklP.png"/> |
+| 0   | E'live Brescia Tv | [>](https://59d7d6f47d7fc.streamlock.net/elivebresciatv/elivebresciatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bZ3B7pi.png"/> |
 | 0   | Easy Tv | [>](https://streamlive.arcapuglia.it:8080/live/canale190/index.m3u8) | <img height="20" src="https://i.imgur.com/LKrVuRR.jpg"/> |
 | 0   | Entella Tv | [>](https://5f22d76e220e1.streamlock.net:443/EntellaTV/EntellaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1VPXKrW.png"/> |
 | 0   | Espansione Tv | [>](https://srvx1.selftv.video/espansione/smil:live.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/mm9HKpD.png"/> |
-| 0   | Esperia Tv | [>](http://wms.shared.streamshow.it/esperiatv/esperiatv/chunklist_w1096393748.m3u8) | <img height="20" src="https://patbuweb.com/tivustream/chanlogoz/ita/esperiatv.png"/> |
+| 0   | Esperia Tv | [>](https://59d8c0cee6f3d.streamlock.net/esperiatv/esperiatv/playlist.m3u8) | <img height="20" src="https://patbuweb.com/tivustream/chanlogoz/ita/esperiatv.png"/> |
 | 0   | Etna Espresso Channel | [>](https://5db313b643fd8.streamlock.net/Etnachannelponte/Etnachannelponte/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hMUxytZ.png"/> |
 | 0   | Etv Marche | [>](https://live.ipstream.it/etvmarche/etvmarche.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4UO7q69.png"/> |
 | 0   | Etv Rete7 | [>](https://live.ipstream.it/etv/etv.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gwj65qg.jpg"/> |
 | 0   | Euro Tv | [>](https://5f22d76e220e1.streamlock.net/eurotv/eurotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HCl5Zbu.png"/> |
 | 0   | FM Tv Marche | [>](https://cloudtv.azotosolutions.com:9553/media/media/playlist.m3u8) | <img height="20" src="https://i.imgur.com/yY01NhL.jpg"/> |
-| 0   | Fano Tv (Canale17) | [>](https://5cbd3bc28341f.streamlock.net:444/fanotv_live/_definst_/43DA-3923-9C72-4E9F/chunklist_w1207024846.m3u8) | <img height="20" src="https://i.imgur.com/39oS1s4.jpg"/> |
+| 0   | Fano Tv (Canale17) | [>](https://5cbd3bc28341f.streamlock.net:444/fanotv_live/_definst_/43DA-3923-9C72-4E9F/playlist.m3u8) | <img height="20" src="https://i.imgur.com/39oS1s4.jpg"/> |
 | 0   | GRP Televisione | [>](https://5cbd3bc28341f.streamlock.net:444/grp/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1zNPpVE.png"/> |
 | 0   | Giornale Radio Tv | [>](https://5db313b643fd8.streamlock.net:443/GiornaleRadioTelevision/GiornaleRadioTelevision/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TMtvCLL.jpg"/> |
 | 0   | Gold 78 HD  | [>](http://stream2.xdevel.com/video1s86-22/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/2UHu1ye.png"/> |
@@ -139,16 +139,16 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | La3 Marsala | [>](https://tsw.streamingwebtv24.it:1936/eslife1/eslife1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/XlxpfEx.png"/> |
 | 0   | LaC News 24 | [>](https://cdn.mainstreaming.tv/live/100532/HVvPMzy/playlist.m3u8?rnd=861954) | <img height="20" src="https://i.imgur.com/02vCECa.png"/> |
 | 0   | LaC Tv Calabria | [>](http://streamcdnb9-f5842579ff984c1c98d63b8d789673eb.msvdn.net/live/100197/SOrBDPy/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2Ef6crS.png"/> |
-| 0   | Lab Tv | [>](http://live.sloode.com:1935/labtv_live/labtv/chunklist_w2038941170.m3u8) | <img height="20" src="https://i.imgur.com/OpRS6Fl.png"/> |
+| 0   | Lab Tv | [>](http://live.sloode.com:1935/labtv_live/labtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OpRS6Fl.png"/> |
 | 0   | Lazio Tv | [>](http://151.0.207.99:1935/live/LAZIOTV12/playlist.m3u8) | <img height="20" src="https://i.imgur.com/6gbWHvP.jpg"/> |
 | 0   | Le Cronache Lucane Tv | [>](http://stucazz.com:8888/hls/cronache.m3u8) | <img height="20" src="https://i.imgur.com/EBY3IZL.jpg"/> |
-| 0   | Lira Tv | [>](https://5e06222f4d978.streamlock.net/liratv/liratv1500/chunklist_w409119112.m3u8) | <img height="20" src="https://i.imgur.com/S0ReVEo.png"/> |
+| 0   | Lira Tv | [>](https://5e06222f4d978.streamlock.net/liratv/liratv1500/playlist.m3u8) | <img height="20" src="https://i.imgur.com/S0ReVEo.png"/> |
 | 0   | Lombardia Tv | [>](https://5db313b643fd8.streamlock.net/LOMBARDIATV/LOMBARDIATV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/aksVy9f.jpg"/> |
 | 0   | Love in Venice | [>](http://59d7d6f47d7fc.streamlock.net/loveinvenice/loveinvenice/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lLBzzce.png"/> |
 | 0   | Lucania Tv | [>](http://wms.shared.streamshow.it:80/lucaniatv/lucaniatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wuUNVR5.png"/> |
 | 0   | Made in BO | [>](https://srvx1.selftv.video/dmchannel/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WFnrMS0.png"/> |
 | 0   | Media Tv | [>](http://live.sloode.com:1935/mediatv/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WFiRWO9.png"/> |
-| 0   | Mediterranea Tv | [>](https://59bb40cf810aa.streamlock.net:4443/streamingvincente/streamingvincente/chunklist_w1462632196.m3u8) | <img height="20" src="https://i.imgur.com/GUTOqRt.png"/> |
+| 0   | Mediterranea Tv | [>](https://59bb40cf810aa.streamlock.net:4443/streamingvincente/streamingvincente/playlist.m3u8) | <img height="20" src="https://i.imgur.com/GUTOqRt.png"/> |
 | 0   | Medjugorje Italia Tv | [>](https://5f22d76e220e1.streamlock.net/medjugorjeitaliatv/medjugorjeitaliatv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hkZScXf.png"/> |
 | 0   | Medjugorje Tv Puglia  | [>](https://streamlive.arcapuglia.it:8080/live/medjugorietv/index.m3u8) | <img height="20" src="https://i.imgur.com/IWBeddh.png"/> |
 | 0   | Minformo Tv | [>](https://5db313b643fd8.streamlock.net:443/MinformoTV/MinformoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/VJNtnZM.jpg"/> |
@@ -160,12 +160,12 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Nuova Tv 1  | [>](https://nuovatv.net:8443/tv/stream.m3u8) | <img height="20" src="https://i.imgur.com/1yqTZhR.png"/> |
 | 0   | Nuova Tv 2 | [>](https://nuovatv.net:8443/tv2/stream.m3u8) | <img height="20" src="https://i.imgur.com/0vauyV3.png"/> |
 | 0   | Odeon | [>](https://5f11919dca3bd.streamlock.net/odeon177/odeon177/playlist.m3u8) | <img height="20" src="https://i.imgur.com/M1tVBuH.png"/> |
-| 0   | Ofanto Tv | [>](http://media.az-mediaserver.com:1935/7446/7446/chunklist_w454796868.m3u8) | <img height="20" src="https://i.imgur.com/UCgATWn.png"/> |
+| 0   | Ofanto Tv | [>](http://media.az-mediaserver.com:1935/7446/7446/playlist.m3u8) | <img height="20" src="https://i.imgur.com/UCgATWn.png"/> |
 | 0   | Onda Novara Tv | [>](https://585b674743bbb.streamlock.net/9006/9006/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Qoh9CFy.png"/> |
 | 0   | Onda Tv Sicilia | [>](https://5926fc9c7c5b2.streamlock.net/9040/9040/playlist.m3u8) | <img height="20" src="https://i.imgur.com/0c5Y6lr.png"/> |
 | 0   | Onda Web Radio | [>](http://178.33.224.197:1935/ondaradioweb/ondaradioweb/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3hTvrC8.jpg"/> |
 | 0   | One Tv E.R. | [>](https://5db313b643fd8.streamlock.net:443/OneTvEmilia/OneTvEmilia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/iAg0Kjl.png"/> |
-| 0   | Ora Tv | [>](https://5db313b643fd8.streamlock.net/OraTv/OraTv/chunklist_w1858583108.m3u8) | <img height="20" src="https://i.imgur.com/clWVrvE.png"/> |
+| 0   | Ora Tv | [>](https://5db313b643fd8.streamlock.net/OraTv/OraTv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/clWVrvE.png"/> |
 | 0   | Orler Tv | [>](https://w1.mediastreaming.it/orlertv/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dBkxD8e.png"/> |
 | 0   | Padre Pio Tv | [>](https://600f07e114306.streamlock.net/PadrePioTV/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/7ajxEPH.png"/> |
 | 0   | Paradise Tv | [>](https://tsw.streamingwebtv24.it:1936/paradisetv/paradisetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/okIBfIb.jpg"/> |
@@ -188,7 +188,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | RDE Tv | [>](https://visual.shoutca.st:1936/saiuz2/rde/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NiwPlrr.png"/> |
 | 0   | Radio Colonna Tv | [>](https://5f22d76e220e1.streamlock.net/rctv/rctv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/EcQvDfq.png"/> |
 | 0   | Radio Italia Cina Tv | [>](https://585b674743bbb.streamlock.net/9054/9054/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QGkyrO3.png"/> |
-| 0   | Radio Monte Kronio Tv (R.M.K.) | [>](http://vod1.kronopress.com:1935/tmk_live/5123-CA5C-9EBE-428A/chunklist_w758377964.m3u8) | <img height="20" src="https://i.imgur.com/t0I2Shi.jpg"/> |
+| 0   | Radio Monte Kronio Tv (R.M.K.) | [>](http://vod1.kronopress.com:1935/tmk_live/5123-CA5C-9EBE-428A/playlist.m3u8) | <img height="20" src="https://i.imgur.com/t0I2Shi.jpg"/> |
 | 0   | Reggio Tv | [>](https://59d7d6f47d7fc.streamlock.net/reggiotv/reggiotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/merrg2C.png"/> |
 | 0   | Rete 55 | [>](https://stream.internet.one/Rete55_Live/index.m3u8) | <img height="20" src="https://i.imgur.com/EsZn2cj.png"/> |
 | 0   | Rete 7 Tv | [>](https://stream.ets-sistemi.it/live.rete7/rete7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lUTxfoh.png"/> |
@@ -199,16 +199,16 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Rete Mia  | [>](https://5db313b643fd8.streamlock.net/Retemia/Retemia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kCJ621Q.png"/> |
 | 0   | Rete Oro Tv | [>](https://5926fc9c7c5b2.streamlock.net/9094/9094/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rkN64Gb.png"/> |
 | 0   | Rete Sole (Lazio) | [>](http://5c389faa13be3.streamlock.net:1935/8056/8056/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ajaa5pk.png"/> |
-| 0   | Rete Sole (Umbria) | [>](http://5c389faa13be3.streamlock.net:1935/8058/8058/chunklist_w696604988.m3u8) | <img height="20" src="https://i.imgur.com/u0ezKgE.png"/> |
-| 0   | Rete Tv Italia | [>](https://57068da1deb21.streamlock.net/retetvitalia/retetvitalia/chunklist_w992954157.m3u8) | <img height="20" src="https://i.imgur.com/lXGWoV9.png"/> |
-| 0   | Rete Veneta | [>](http://wms.shared.streamshow.it/reteveneta/reteveneta/chunklist_w1047580983.m3u8) | <img height="20" src="https://i.imgur.com/cInhQFp.png"/> |
+| 0   | Rete Sole (Umbria) | [>](http://5c389faa13be3.streamlock.net:1935/8058/8058/playlist.m3u8) | <img height="20" src="https://i.imgur.com/u0ezKgE.png"/> |
+| 0   | Rete Tv Italia | [>](https://57068da1deb21.streamlock.net/retetvitalia/retetvitalia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lXGWoV9.png"/> |
+| 0   | Rete Veneta | [>](http://wms.shared.streamshow.it/reteveneta/reteveneta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/cInhQFp.png"/> |
 | 0   | Rossini Tv | [>](https://5cbd3bc28341f.streamlock.net:444/rossinitv_live/944A-63A6-9EB8-4492/playlist.m3u8) | <img height="20" src="https://i.imgur.com/K0Em0nx.jpg"/> |
 | 0   | Rtc Targato Napoli | [>](https://eu1.servers10.com:8081/8014/index.m3u8) | <img height="20" src="https://i.imgur.com/Jsep7uM.png"/> |
 | 0   | Rtp Tv | [>](http://flash2.xdevel.com/rtptv/rtptv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I1hYI0C.png"/> |
 | 0   | Rttr | [>](https://5f204aff97bee.streamlock.net/RTTRlive/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z7xMArA.png"/> |
 | 0   | Rtv 38 Toscana | [>](http://845d8509d2cb4f249dd0b2ae5755b6c2.msvdn.net/live/S12268608/CXHH7K39hg9K/playlist.m3u8) | <img height="20" src="https://i.imgur.com/xqlhJqK.png"/> |
 | 0   | Rtv Calabria | [>](https://59d7d6f47d7fc.streamlock.net/reggiotv/reggiotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Ytwyx8D.png"/> |
-| 0   | SL 48 Tv | [>](http://media.velcom.it:1935/sl48/sl48/chunklist_w751971098.m3u8) | <img height="20" src="https://i.imgur.com/b58oouu.jpg"/> |
+| 0   | SL 48 Tv | [>](http://media.velcom.it:1935/sl48/sl48/playlist.m3u8) | <img height="20" src="https://i.imgur.com/b58oouu.jpg"/> |
 | 0   | ST Europe Channel | [>](https://5f22d76e220e1.streamlock.net/steuropetv/steuropetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/T7kyY2p.png"/> |
 | 0   | Sardegna 1 | [>](https://59d8c0cee6f3d.streamlock.net/sardegnauno/sardegnauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qRRGn1e.png"/> |
 | 0   | Set Tv Cilento  | [>](https://stream1.aswifi.it/settv/live/index.m3u8) | <img height="20" src="https://i.imgur.com/qN5D1jD.png"/> |
@@ -216,7 +216,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Sicilia Tv | [>](https://5f22d76e220e1.streamlock.net/SiciliaTV/SiciliaTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I5FoThW.png"/> |
 | 0   | Sienatv | [>](https://flash8.xdevel.com/sienatv/sienatv/master.m3u8) | <img height="20" src="https://i.imgur.com/gcysky4.png"/> |
 | 0   | Siracusa Live Tv  | [>](https://5db313b643fd8.streamlock.net/SRLIVE_1/SRLIVE_1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/oyPkDnz.jpg"/> |
-| 0   | Sophia Tv | [>](https://www.onairport.live/sophiatv-it-live/livestream_low/chunklist_w217998957.m3u8) | <img height="20" src="https://i.imgur.com/fiLNK3b.jpg"/> |
+| 0   | Sophia Tv | [>](https://www.onairport.live/sophiatv-it-live/livestream_low/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fiLNK3b.jpg"/> |
 | 0   | Stiletv | [>](http://convision2.convergenze.it/hls-live/livepkgr/_definst_/liveevent/livestream1.m3u8) | <img height="20" src="https://i.imgur.com/v5Grhff.jpg"/> |
 | 0   | Studio 100 | [>](http://wms.shared.streamshow.it:1935/studio100ta/studio100ta/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z84qFXd.png"/> |
 | 0   | Super J Tv | [>](http://uk4.streamingpulse.com:1935/SuperJtv/SuperJtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/5oy5Nuu.png"/> |
@@ -224,17 +224,17 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Supertv | [>](http://wms.shared.streamshow.it:1935/supertv/supertv/live.m3u8) | <img height="20" src="https://i.imgur.com/7gUZcEh.png"/> |
 | 0   | T.R.L Tele Radio Leo | [>](https://5db313b643fd8.streamlock.net/TRL/TRL/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qAagkJT.png"/> |
 | 0   | T.S.E. Uno (Tele Scout Europa) | [>](http://stream.mariatvcdn.com/tse/bd5a2cb40637623177295aed22db25f9.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OA0PRsb.png"/> |
-| 0   | T9 | [>](https://5f11919dca3bd.streamlock.net/t9/t9/chunklist_w1829149389.m3u8) | <img height="20" src="https://i.imgur.com/vlJaxJl.png"/> |
+| 0   | T9 | [>](https://5f11919dca3bd.streamlock.net/t9/t9/playlist.m3u8) | <img height="20" src="https://i.imgur.com/vlJaxJl.png"/> |
 | 0   | TRC Santeramo | [>](https://59d7d6f47d7fc.streamlock.net/trc/trc/playlist.m3u8) | <img height="20" src="https://i.imgur.com/VbYdS8P.jpg"/> |
-| 0   | TSD Tv Arezzo(Tele San Domenico) | [>](https://stream.mariatvcdn.com/tsd/7c59373bfdb38201b9215ff86f0ce6af.sdp/chunks.m3u8) | <img height="20" src="https://i.imgur.com/WQ8eQXc.png"/> |
+| 0   | TSD Tv Arezzo(Tele San Domenico) | [>](https://stream.mariatvcdn.com/tsd/7c59373bfdb38201b9215ff86f0ce6af.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WQ8eQXc.png"/> |
 | 0   | TVL (TV Libera Pistoia) | [>](http://live.mariatvcdn.com/mariatvcdn/70564e1c6884c007c76f0c128d679eed.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/07geF0L.png"/> |
 | 0   | Tcf Tv | [>](http://live.sloode.com:1935/tcf_live/telecineforum/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fiylFs2.jpg"/> |
 | 0   | Teatro Tv | [>](https://m.iostream.it/hls/teatrotv/teatrotv.m3u8) | <img height="20" src="https://i.imgur.com/UsvffQL.png"/> |
 | 0   | Tele A | [>](http://82.62.190.94/hls/telea/video.m3u8) | <img height="20" src="https://i.imgur.com/l7Za9KH.jpg"/> |
 | 0   | Tele Abruzzo Tv | [>](http://uk4.streamingpulse.com:1935/TeleabruzzoTV/TeleabruzzoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/koB8J4b.jpg"/> |
 | 0   | Tele Acras | [>](https://5cbd3bc28341f.streamlock.net:444/teleacras/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/90Lsv8q.png"/> |
-| 0   | Tele Arena | [>](https://5e73cf528f404.streamlock.net/TeleArena/TeleArena.stream/chunklist_w188795637.m3u8) | <img height="20" src="https://i.imgur.com/9hsoWMO.png"/> |
-| 0   | Tele Argento/Magic Tv | [>](http://163.172.88.73:1935/magic_web/site/chunklist_w1342104039.m3u8) | <img height="20" src="https://i.imgur.com/gseTf4W.jpg"/> |
+| 0   | Tele Arena | [>](https://5e73cf528f404.streamlock.net/TeleArena/TeleArena.stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9hsoWMO.png"/> |
+| 0   | Tele Argento/Magic Tv | [>](http://163.172.88.73:1935/magic_web/site/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gseTf4W.jpg"/> |
 | 0   | Tele Bari | [>](https://w1.mediastreaming.it/telebari/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HYSz4rx.png"/> |
 | 0   | Tele Belluno | [>](https://live.mariatvcdn.com/telebelluno/a3b80388da9801906adf885282e73bc3.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/YiM2Z7E.png"/> |
 | 0   | Tele Blu | [>](https://58d921499d3d3.streamlock.net/Teleblu/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/NWMTlry.jpg"/> |
@@ -247,8 +247,8 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tele Clusone Bergamo | [>](https://media.streambrothers.com:1936/8546/8546/playlist.m3u8) | <img height="20" src="https://i.imgur.com/dVDY1ng.png"/> |
 | 0   | Tele Color Lombardia | [>](http://cdn.mainstreaming.tv/live/324149/hlbAWtl/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hUA29XI.jpg"/> |
 | 0   | Tele Cupole | [>](http://live.livevideosolution.it/telecupole/dd6d85e5b7452f7b85a099509292b421.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ZmUI9zb.png"/> |
-| 0   | Tele Estense | [>](https://5e73cf528f404.streamlock.net/TeleEstense/livestream/chunklist_w530758405.m3u8) | <img height="20" src="https://i.imgur.com/X7i7DWo.png"/> |
-| 0   | Tele Foggia | [>](http://wms.shared.streamshow.it/telefoggia/mp4:telefoggia/chunklist_w386788975.m3u8) | <img height="20" src="https://i.imgur.com/M7tqBu9.jpg"/> |
+| 0   | Tele Estense | [>](https://5e73cf528f404.streamlock.net/TeleEstense/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/X7i7DWo.png"/> |
+| 0   | Tele Foggia | [>](http://wms.shared.streamshow.it/telefoggia/mp4:telefoggia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/M7tqBu9.jpg"/> |
 | 0   | Tele Friuli | [>](https://streamtechglobal.akamaized.net/hls/live/2024685/telefriuli/Group01/2024685-telefriuli/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/AoQxZxD.png"/> |
 | 0   | Tele Gela | [>](http://live.sloode.com:1935/qdg_live/AF74-FF2C-7350-41F2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sjrxbgP.png"/> |
 | 0   | Tele Genova | [>](https://5db313b643fd8.streamlock.net/Telegenova/Telegenova/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BXvPBKb.png"/> |
@@ -263,10 +263,10 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tele Mistretta Life e Family | [>](https://stream.mariatvcdn.com/telemistrettalive2/ddbcd59a192d6f92336991e344fa1821.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/y2LLwiy.png"/> |
 | 0   | Tele Mistretta Radio | [>](https://stream.mariatvcdn.com/telemistrettaradio/900bfcc0f9012ea272584fd5ff5281b8.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/d7O7Uqa.png"/> |
 | 0   | Tele Mistretta | [>](https://live.mariatvcdn.com/telemistretta/8fbcd205ada81b295ee6c211c3a80dde.sdp/playlist.m3u8) | <img height="20" src="https://i.imgur.com/OJ3zUS0.png"/> |
-| 0   | Tele Molise | [>](http://185.202.128.1:1935/TelemoliseStream/telemoliseTV.stream_tlm/chunklist_w1170267390.m3u8) | <img height="20" src="https://i.imgur.com/u5VD0x9.png"/> |
+| 0   | Tele Molise | [>](http://185.202.128.1:1935/TelemoliseStream/telemoliseTV.stream_tlm/playlist.m3u8) | <img height="20" src="https://i.imgur.com/u5VD0x9.png"/> |
 | 0   | Tele Monteneve 3 | [>](http://wms.shared.streamshow.it/telemonteneve3/telemonteneve3/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LJhQApn.jpg"/> |
 | 0   | Tele Norba (TG Norba 24 )| [>](https://flash2.xdevel.com/tgnorba_24/tgnorba_24_source.stream/manifest.mpd) | <img height="20" src="https://i.imgur.com/9MhrrJK.png"/> |
-| 0   | Tele Nord Est | [>](https://59d7d6f47d7fc.streamlock.net/telenord/telenord/chunklist_w2111676469.m3u8) | <img height="20" src="https://i.imgur.com/TakoSUX.png"/> |
+| 0   | Tele Nord Est | [>](https://59d7d6f47d7fc.streamlock.net/telenord/telenord/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TakoSUX.png"/> |
 | 0   | Tele Nord Genova | [>](https://5db313b643fd8.streamlock.net/Telenord/Telenord/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gQWB9Gx.png"/> |
 | 0   | Tele Nostra | [>](https://meridelive-lh.akamaihd.net/i/ottop_1@118465/index_1_av-p.m3u8?sd=10&amp;rebase=on) | <img height="20" src="https://i.imgur.com/FACahKZ.png"/> |
 | 0   | Tele Occidente | [>](http://ciaoitalystream.ddns.net/live/webTELEOCCIDENTEweb/montelepre@palermo/2.m3u8) | <img height="20" src="https://i.imgur.com/3aOiWKa.png"/> |
@@ -284,13 +284,13 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tele Pegaso | [>](https://flash2.xdevel.com/telepegasocanale812/telepegasocanale812/playlist.m3u8) | <img height="20" src="https://i.imgur.com/FQkM8Vd.png"/> |
 | 0   | Tele Piadena  | [>](https://stream3.xdevel.com/video0s975441-151/stream/playlist_dvr.m3u8) | <img height="20" src="https://i.imgur.com/VqaPuQN.png"/> |
 | 0   | Tele Pordenone | [>](https://video.wifi4all.it/telepn/telepn.m3u8) | <img height="20" src="https://i.imgur.com/dbYwXwg.png"/> |
-| 0   | Tele Prima | [>](http://live.sloode.com:1935/teleprima/live/chunklist_w268781554.m3u8) | <img height="20" src="https://i.imgur.com/WLziQCV.png"/> |
-| 0   | Tele Quattro Trieste | [>](http://wms.shared.streamshow.it/telequattro/telequattro/chunklist_w1388066579.m3u8) | <img height="20" src="https://i.imgur.com/MFxQxve.png"/> |
+| 0   | Tele Prima | [>](http://live.sloode.com:1935/teleprima/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/WLziQCV.png"/> |
+| 0   | Tele Quattro Trieste | [>](http://wms.shared.streamshow.it/telequattro/telequattro/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MFxQxve.png"/> |
 | 0   | Tele Radio Ercolano | [>](https://eu1.servers10.com:8081/8012/index.m3u8) | <img height="20" src="https://i.imgur.com/YPuoy8N.jpg"/> |																																												   
 | 0   | Tele Radio Orte | [>](https://flash2.xdevel.com/ortetv/ortetv/index.m3u8) | <img height="20" src="https://i.imgur.com/uX2uxvN.png"/> |
 | 0   | Tele Radio Sciacca | [>](http://5cbd3bc28341f.streamlock.net:1935/trs_live/teleradiosciacca-tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/suhz5mE.png"/> |
-| 0   | Tele Radio Studio 5 | [>](http://mars.az-streamingserver.com:1935/7444/7444/chunklist_w1479892021.m3u8) | <img height="20" src="https://i.imgur.com/lPRjSor.jpg"/> |
-| 0   | Tele Rama | [>](https://58d921499d3d3.streamlock.net/TeleRama/livestream/chunklist_w1747460348.m3u8) | <img height="20" src="https://i.imgur.com/enfqUlI.jpg"/> |
+| 0   | Tele Radio Studio 5 | [>](http://mars.az-streamingserver.com:1935/7444/7444/playlist.m3u8) | <img height="20" src="https://i.imgur.com/lPRjSor.jpg"/> |
+| 0   | Tele Rama | [>](https://58d921499d3d3.streamlock.net/TeleRama/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/enfqUlI.jpg"/> |
 | 0   | Tele Roma 1 | [>](https://flash2.xdevel.com/teleromauno/teleromauno/playlist.m3u8) | <img height="20" src="https://i.imgur.com/3t7JWrf.png"/> |
 | 0   | Tele Romagna 24 | [>](http://livetr.teleromagna.it/mia/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Bpml478.png"/> |
 | 0   | Tele Romagna Lifestyle | [>](http://livetr.teleromagna.it/lifestyle/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gup84Sb.png"/> |
@@ -308,8 +308,8 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tele Tutto 24 | [>](https://600f07e114306.streamlock.net/TT24_TELETUTTO/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/weKWQgx.png"/> |
 | 0   | Tele Tutto | [>](https://600f07e114306.streamlock.net/TT_TELETUTTO/smil:TT.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/sZxMP7g.png"/> |
 | 0   | Tele Venezia | [>](https://59d8c0cee6f3d.streamlock.net/televenezia/televenezia/playlist.m3u8) | <img height="20" src="https://i.imgur.com/SavGpCE.jpg"/> |
-| 0   | Tele Video Agrigento (T.V.A.) | [>](https://59d7d6f47d7fc.streamlock.net/tva/tva/chunklist_w2057719642.m3u8) | <img height="20" src="https://i.imgur.com/AaPr63E.png"/> |
-| 0   | TeleMajg | [>](https://59d7d6f47d7fc.streamlock.net/telemajg/telemajg/chunklist_w656612441.m3u8) | <img height="20" src="https://i.imgur.com/9tefonp.jpg"/> |
+| 0   | Tele Video Agrigento (T.V.A.) | [>](https://59d7d6f47d7fc.streamlock.net/tva/tva/playlist.m3u8) | <img height="20" src="https://i.imgur.com/AaPr63E.png"/> |
+| 0   | TeleMajg | [>](https://59d7d6f47d7fc.streamlock.net/telemajg/telemajg/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9tefonp.jpg"/> |
 | 0   | TeleRent 7Gold | [>](http://stream2.xdevel.com/video0s86-21/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wjZT8De.png"/> |
 | 0   | Telesud Trapani | [>](https://5cbd3bc28341f.streamlock.net:444/telesud/_definst_/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/tpZvU1P.png"/> |
 | 0   | Teleuniverso | [>](https://media.velcom.it:19360/teleuniverso/teleuniverso.m3u8) | <img height="20" src="https://i.imgur.com/u8E9wBb.png"/> |
@@ -324,7 +324,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tsn Tele Sondrio News | [>](http://wms.shared.streamshow.it/tsn/tsn_mobile/playlist.m3u8) | <img height="20" src="https://i.imgur.com/24Anl5o.png"/> |
 | 0   | Tua Channel | [>](https://media2021.rtvweb.com/promovideo_web/tuachannel/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BDdQvtS.png"/> |
 | 0   | Tuscia Sabina 2000Tv | [>](http://ts2000tv.streaming.nextware.it:8081/ts2000tv/ts2000tv/chunks.m3u8) | <img height="20" src="https://i.imgur.com/Tq5nEAy.png"/> |
-| 0   | Tv 6 | [>](http://185.202.128.1:1935/Tv6Stream/tv6TV.stream_tlm/chunklist_w16775241.m3u8) | <img height="20" src="https://i.imgur.com/bJ2e604.png"/> |
+| 0   | Tv 6 | [>](http://185.202.128.1:1935/Tv6Stream/tv6TV.stream_tlm/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bJ2e604.png"/> |
 | 0   | Tv Campane 1 | [>](https://eu1.servers10.com:8081/8032/index.m3u8) | <img height="20" src="https://i.imgur.com/UrHKovD.jpg"/> |
 | 0   | Tv Campania Streaming | [>](https://eu1.servers10.com:8081/8020/index.m3u8) | <img height="20" src="https://i.imgur.com/5Ly6LyC.png"/> |
 | 0   | Tv Luna Napoli  | [>](https://streamlive.arcapuglia.it:8080/live/teleluna/index.m3u8) | <img height="20" src="https://i.imgur.com/jxhuoyE.png"/> |
@@ -347,10 +347,10 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Video Mediterraneo | [>](http://stream.ets-sistemi.it:1935/live.rvm/rvmtv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/hJHC3uQ.png"/> |
 | 0   | Video Nola | [>](http://stream1.aswifi.it/videonola/live/index.m3u8) | <img height="20" src="https://i.imgur.com/M5z5UoD.jpg"/> |
 | 0   | Video Star | [>](https://5cbd3bc28341f.streamlock.net:444/videostar_live/_definst_/videostar/playlist.m3u8) | <img height="20" src="https://i.imgur.com/1ddJVZ7.jpg"/> |
-| 0   | Videolina | [>](http://livestreaming.videolina.it/live/Videolina/chunklist_w488279894.m3u8) | <img height="20" src="https://i.imgur.com/bnDZJwd.gif"/> |
+| 0   | Videolina | [>](http://livestreaming.videolina.it/live/Videolina/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bnDZJwd.gif"/> |
 | 0   | Videostar Tv Lombardia | [>](http://dreamsiteradiocpvideo.com:1935/vds/vds/playlist.m3u8) | <img height="20" src="https://i.imgur.com/ecpPFZL.jpg"/> |
 | 0   | Vintage Radio Tv | [>](https://stream4.xdevel.com/video0s975967-804/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/n3LtBNT.jpg"/> |
-| 0   | Vuemme Tv | [>](https://5db313b643fd8.streamlock.net/Vuemme/Vuemme/chunklist_w1853927005.m3u8) | <img height="20" src="https://i.imgur.com/x5A0xU6.png"/> |
+| 0   | Vuemme Tv | [>](https://5db313b643fd8.streamlock.net/Vuemme/Vuemme/playlist.m3u8) | <img height="20" src="https://i.imgur.com/x5A0xU6.png"/> |
 | 0   | Well Tv | [>](https://59d7d6f47d7fc.streamlock.net/welltv/welltv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Kqgz4Na.png"/> |
 | 0   | Yvii Tv | [>](rtmp://yviistreamer.kernel.online:1935/live/yviitv) | <img height="20" src="https://i.imgur.com/yP5AvDo.png"/> |
 | 0   | Zerouno Tv News | [>](https://5db313b643fd8.streamlock.net/ZerounoTVEventi/ZerounoTVEventi/playlist.m3u8) | <img height="20" src="https://i.imgur.com/vxRzyjE.png"/> |

--- a/italy.md
+++ b/italy.md
@@ -394,8 +394,9 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 4548 | Family – Rakuten TV | [>](https://rakuten-family-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/BCC123A.jpg"/> |
 | 4549 | Drammatico – Rakuten TV | [>](https://rakuten-tvshows-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Nx3JzZK.jpg"/> |
 | 4550 | Film d'azione – Rakuten TV | [>](https://rakuten-actionmovies-6-it.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KDmDQM6.jpg"/> |
-| 5000 | Classico – Rakuten TV | [>](https://rakuten-classico-1-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
-| 5001 | Film Top – Rakuten TV | [>](https://rakuten-topfree-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
+| 5000 | Film Top – Rakuten TV | [>](https://rakuten-topfree-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
+| 5005 | Classico – Rakuten TV | [>](https://rakuten-classico-1-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
+| 5009 | Romance – Rakuten TV | [>](https://rakuten-romance-6-eu.rakuten.wurl.tv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/wSfLgHs.png"/> |
 
 <h2>Invalid</h2>
 

--- a/italy.md
+++ b/italy.md
@@ -90,8 +90,6 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Aurora Arte | [>](https://59d7d6f47d7fc.streamlock.net/auroraarte/auroraarte/chunklist.m3u8) | <img height="20" src="https://i.imgur.com/BoLZ5wG.png"/> |
 | 0   | Azzurra Tv Vco | [>](http://sb.top-ix.org:1935/avtvlive/streaming/chunklist_w1605488247.m3u8) | <img height="20" src="https://i.imgur.com/mSWw8uW.png"/> |
 | 0   | Basilicata 1 Tv | [>](http://77.68.40.210:8888/hls/basilicata1.m3u8) | <img height="20" src="https://i.imgur.com/VS6CQ88.png"/> |
-| 0   | Bergamo Tv | [>](http://api.new.livestream.com/accounts/245066/events/3063596/live.m3u8) | <img height="20" src="https://i.imgur.com/1doR6Vl.png"/> |
-| 0   | Byoblu Tv | [>](https://player-api.new.livestream.com/accounts/29084624/events/9394322/broadcasts/223051863.secure.m3u8) | <img height="20" src="https://i.imgur.com/KldC2gI.png"/> |
 | 0   | Cafe Tv 24 | [>](http://srv3.meway.tv:1957/cafe/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KbcbxFw.png"/> |
 | 0   | Calabria Uno TV  | [>](https://5f22d76e220e1.streamlock.net/calabriaunotv/calabriaunotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2TK1GQ5.png"/> |
 | 0   | Calabria tv | [>](https://5db313b643fd8.streamlock.net:443/CalabriaTv2/CalabriaTv2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qWirucd.png"/> |
@@ -161,6 +159,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Nuova TV Nazionale | [>](https://stream4.xdevel.com/video0s975955-782/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QWlRuXg.png"/> |
 | 0   | Nuova Tv 1  | [>](https://nuovatv.net:8443/tv/stream.m3u8) | <img height="20" src="https://i.imgur.com/1yqTZhR.png"/> |
 | 0   | Nuova Tv 2 | [>](https://nuovatv.net:8443/tv2/stream.m3u8) | <img height="20" src="https://i.imgur.com/0vauyV3.png"/> |
+| 0   | Odeon | [>](https://5f11919dca3bd.streamlock.net/odeon177/odeon177/playlist.m3u8) | <img height="20" src="https://i.imgur.com/M1tVBuH.png"/> |
 | 0   | Ofanto Tv | [>](http://media.az-mediaserver.com:1935/7446/7446/chunklist_w454796868.m3u8) | <img height="20" src="https://i.imgur.com/UCgATWn.png"/> |
 | 0   | Onda Novara Tv | [>](https://585b674743bbb.streamlock.net/9006/9006/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Qoh9CFy.png"/> |
 | 0   | Onda Tv Sicilia | [>](https://5926fc9c7c5b2.streamlock.net/9040/9040/playlist.m3u8) | <img height="20" src="https://i.imgur.com/0c5Y6lr.png"/> |
@@ -230,7 +229,6 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | TSD Tv Arezzo(Tele San Domenico) | [>](https://stream.mariatvcdn.com/tsd/7c59373bfdb38201b9215ff86f0ce6af.sdp/chunks.m3u8) | <img height="20" src="https://i.imgur.com/WQ8eQXc.png"/> |
 | 0   | TVL (TV Libera Pistoia) | [>](http://live.mariatvcdn.com/mariatvcdn/70564e1c6884c007c76f0c128d679eed.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/07geF0L.png"/> |
 | 0   | Tcf Tv | [>](http://live.sloode.com:1935/tcf_live/telecineforum/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fiylFs2.jpg"/> |
-| 0   | Tci | [>](https://player-api.new.livestream.com/accounts/27460990/events/8287184/broadcasts/223071659.secure.m3u8) | <img height="20" src="https://i.imgur.com/lCZTaKs.jpg"/> |
 | 0   | Teatro Tv | [>](https://m.iostream.it/hls/teatrotv/teatrotv.m3u8) | <img height="20" src="https://i.imgur.com/UsvffQL.png"/> |
 | 0   | Tele A | [>](http://82.62.190.94/hls/telea/video.m3u8) | <img height="20" src="https://i.imgur.com/l7Za9KH.jpg"/> |
 | 0   | Tele Abruzzo Tv | [>](http://uk4.streamingpulse.com:1935/TeleabruzzoTV/TeleabruzzoTV/playlist.m3u8) | <img height="20" src="https://i.imgur.com/koB8J4b.jpg"/> |
@@ -258,7 +256,6 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tele Ischia | [>](https://eu1.servers10.com:8081/8130/index.m3u8) | <img height="20" src="https://i.imgur.com/vihHVQn.jpg"/> |
 | 0   | Tele Jonio | [>](http://59d7d6f47d7fc.streamlock.net/telejonio/telejonio/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qJeDV8R.png"/> |
 | 0   | Tele Lazio Nord | [>](http://tln.srfms.com:1935/TLN/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/gZEojVW.png"/> |
-| 0   | Tele Liberta' HD | [>](https://player-api.new.livestream.com/accounts/17114188/events/4902226/broadcasts/223072237.secure.m3u8) | <img height="20" src="https://i.imgur.com/XzAB5k7.jpg"/> |
 | 0   | Tele Liguria Sud | [>](https://live.teleliguriasud.it/hls/tls/index.m3u8) | <img height="20" src="https://i.imgur.com/BeLAYJ6.jpg"/> |
 | 0   | Tele Mantova | [>](https://5ce9406b73c33.streamlock.net/TeleMantova/livestream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/bkSPcs4.png"/> |
 | 0   | Tele Mia Extra | [>](https://player.ilariochiera.it/fileadmin/hls/TelemiaExtra/stream.m3u8) | <img height="20" src="https://i.imgur.com/upzBG32.png"/> |

--- a/italy.md
+++ b/italy.md
@@ -331,6 +331,7 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Tv Prato | [>](https://live.mariatvcdn.com/tvprato/2db0dd5674586686a867ec52c3aa8e06.sdp/mono.m3u8) | <img height="20" src="https://i.imgur.com/zDeVpZd.png"/> |
 | 0   | Tv Qui Modena | [>](https://59d7d6f47d7fc.streamlock.net/tvqui/tvqui/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4bOYlfg.png"/> |
 | 0   | Tv Uno | [>](http://ftp.tiscali.it/francescovernata/TVUNO/monoscopioTvUNOint-1.wmv) | <img height="20" src="https://i.imgur.com/OtCwYsh.jpg"/> |
+| 0   | Tv Yes | [>](https://stream1.aswifi.it/radioyes/live/index.m3u8) | <img height="20" src="https://i.imgur.com/1wsO8U7.png"/> |
 | 0   | Tv7 Azzurra | [>](http://217.61.26.46:8080/hls/azzurra.m3u8) | <img height="20" src="https://i.imgur.com/yYvGWHL.png"/> |
 | 0   | Tv7 News | [>](http://217.61.26.46:8080/hls/news.m3u8) | <img height="20" src="https://i.imgur.com/rlMEE1j.png"/> |
 | 0   | Tv7 Triveneta | [>](http://217.61.26.46:8080/hls/triveneta.m3u8) | <img height="20" src="https://i.imgur.com/O2NF7jJ.jpg"/> |


### PR DESCRIPTION
CHANGELOG: 
- Renamed from "DVB-T" to "National".
- Renamed from "Regionali" to "Regional".
- Reorganized "Regional" section.
- Moved "Super Six" and "7Gold" from "National" to "Regional".
- Deleted duplicated channels from "Regional".
- Deleted "Rtv San Marino" and "Tele Ticino" from "Regional", because already present to "San Marino" and "Switzerland" list.
- Added "Canale 21 Lazio", "NSL" and "Padre Pio Tv" to "Regional".
- Reordered "Samsung TV Plus" channels.
- Added "Film Top – Rakuten TV" to "Samsung TV Plus".

Thank you so much.