### PR TITLE
Create iraq.md

### DIFF
--- a/iraq.md
+++ b/iraq.md
@@ -1,0 +1,17 @@
+<h1>Iraq</h1>
+
+| #   | Channel        | Link  | Logo |
+|:---:|:--------------:|:-----:|:-----:
+| 1   | Al-Hurra Iraq | [>](https://mbnvvideoingest-i.akamaihd.net/hls/live/1004674/MBNV_ALHURRA_IRAQ/master_2596.m3u8) | <img height="20" src="https://i.imgur.com/mXBZEQP.png"/> |
+| 2   | Al-Hurra            | [>](https://mbnvvideoingest-i.akamaihd.net/hls/live/1004673/MBNV_ALHURRA_MAIN/master_2596.m3u8) | <img height="20" src="https://i.imgur.com/0izeu5z.png"/> |
+| 3   | Al-Iraqiya Ⓢ | [>](https://cdn.catiacast.video/abr/8d2ffb0aba244e8d9101a9488a7daa05/playlist.m3u8) | <img height="20" src="https://i.imgur.com/imdV6kL.png"/> |
+| 4   | Al-Rafidain       | [>](https://cdg8.edge.technocdn.com/arrafidaintv/abr_live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/D78qG91.png"/> |
+| 5   | Al-Rasheed       | [>](https://media1.livaat.com/AL-RASHEED-HD/tracks-v1a1/mono.m3u8) | <img height="20" src="https://i.imgur.com/SU9HbXY.png"/> |
+| 6   | Al-Sharqiya News       | [>](https://5d94523502c2d.streamlock.net/alsharqiyalive/mystream/chunklist_w449457930.m3u8) | <img height="20" src="https://i.imgur.com/P6p17ZY.jpg"/> |
+| 7   | Al-Sharqiya       | [>](https://5d94523502c2d.streamlock.net/home/mystream/chunklist_w1408191520.m3u8) | <img height="20" src="https://i.imgur.com/bPYyXNf.png"/> |
+| 8   | Dijlah Tarab       | [>](https://ghaasiflu.online/tarab/tracks-v1a1/mono.m3u8) | <img height="20" src="https://i.imgur.com/2SBjjBQ.png"/> |
+| 9   | Dijlah TV       | [>](https://ghaasiflu.online/Dijlah/tracks-v1a1/mono.m3u8) | <img height="20" src="https://i.imgur.com/FJEeYiz.png"/> |
+| 10  | iNEWS       | [>](https://svs.itworkscdn.net/inewsiqlive/inewsiq.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/PeuBkaH.png"/> |
+| 11  | Iraq Future Ⓢ       | [>](https://streaming.viewmedia.tv/viewsatstream40/viewsatstream40.smil/chunklist_w125001985_b900000.m3u8) | <img height="20" src="https://i.imgur.com/Z7woTe5.png"/> |
+| 12  | Turkmeneli TV       | [>](https://137840.global.ssl.fastly.net/edge/live_6b7c6e205afb11ebb010f5a331abaf98/playlist.m3u8) | <img height="20" src="https://i.imgur.com/iUhhg4B.png"/> |
+| 13  | Zagros TV       | [>](https://5a3ed7a72ed4b.streamlock.net/zagrostv/SMIL:myStream.smil/chunklist_w1543346231_b1700000_sleng_t64MTA4MHA=.m3u8) | <img height="20" src="https://i.imgur.com/UjIuIQX.png"/> |


### PR DESCRIPTION
Al-Iraqiya, Al-Rafidain, Al-Rasheed, Al-Sharqiya News, Al-Sharqiya, Dijlah TV, Dijlah Tarab, iNEWS, Iraq Future, Turkmeneli TV, and Zagros TV are all found in [this list of free-to-air channels](https://en.satexpat.com/tv/iraq). Both Al-Hurra channels are found in [this list](https://en.kingofsat.tv/find.php?&standard=All&ordre=freq&question=ALHURRA-HD&filtre=Clear&aff=zap), and [their official sites](https://www.alhurra.com) provide publicly accessible and free livestreams.  Only found two SD channels among the lot. Thanks for your great work!