### PR TITLE
Remove Current Time

### DIFF
--- a/belarus.md
+++ b/belarus.md
@@ -9,7 +9,6 @@
 | 5   | Belarus 4 Vitebsk Ⓢ | [>](http://95.46.208.8:26258/belarus4) | <img height="20" src="https://i.imgur.com/TW6Ap71.png"/> | Belarus4Vitebsk.by 
 | 6   | CTV Belarus Ⓢ | [>](http://212.98.171.116/HLS/ctvby/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Gz6mSGu.png"/> | STV.by |
 | 7   | Hawe TV Vitebsk Ⓢ | [>](http://95.46.208.8:26259/nashe) | <img height="20" src="https://i.imgur.com/HOb5m5f.jpg"/> | NasheTV.by |
-| 8   | Nastoyashcheye vremya Ⓢ | [>](https://rfe-lh.akamaihd.net/i/rfe_tvmc5@383630/master.m3u8) | <img height="20" src="https://i.imgur.com/z9E3DBW.png"/> | CurrentTimeTV.cz |
 | 9   | Pervyy Muzykal'nyy BY Ⓢ | [>](http://rtmp.one.by:1200) | <img height="20" src="https://i.imgur.com/7tFiG6S.jpg"/> | FirstMusicChannel.by |
 | 10   | Planeta RTR Ⓢ | [>](https://a3569455801-s26881.cdn.ngenix.net/live/smil:rtrp.smil/chunklist_b1600000.m3u8) | <img height="20" src="https://i.imgur.com/yqRuEJd.png"/> | RTRBelarus.by |
 | 11   | Radio HIT Orsk | [>](http://hithd.camsh.orsk.ru/hls/hithd.m3u8) | <img height="20" src="https://i.imgur.com/e2RyN4r.jpg"/> |

--- a/ukraine.md
+++ b/ukraine.md
@@ -11,7 +11,6 @@
 | 8   | BamBarBia TV | [>](http://cdn1.live-tv.od.ua:8081/bbb/bbbtv-abr/bbb/bbbtv-720p/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LIk85IA.png"/> |
 | 9   | BTB Ⓢ | [>](http://video.vtvplus.com.ua:81/hls/online/index.m3u8) | <img height="20" src="https://i.imgur.com/JG493Vn.png"/> |
 | 10   | Che Pe Info Ⓢ | [>](http://109.68.40.67/life/magnolia_3/index.m3u8) | <img height="20" src="https://i.imgur.com/7Ycv3bL.png"/> |
-| 11   | Current Time Ⓢ | [>](https://rfe-lh.akamaihd.net/i/rfe_tvmc5@383630/master.m3u8) | <img height="20" src="https://i.imgur.com/FbKbeGo.png"/> |
 | 12   | Chernivtsi Promin | [>](http://langate.tv/promin/live_720/index.m3u8) | <img height="20" src="https://i.imgur.com/IbwmfzF.png"/> |
 | 13   | CNL Europa Ⓢ | [>](http://live-mobile.cdn01.net/hls-live/202E1F/default/mobile/stream_10429_3.m3u8) | <img height="20" src="https://i.imgur.com/lozzdS7.png"/> |
 | 14   | Duma TV | [>](http://cdn1.live-tv.od.ua:8081/dumska/dumska-abr/dumska/dumska720p/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KlPqxlo.png"/> |


### PR DESCRIPTION
violates rule [No channels made for a country and funded by a different country](https://github.com/Free-TV/IPTV/blob/master/README.md#philosophy):

https://en.wikipedia.org/wiki/Current_Time_TV

> Current Time TV (Russian: Настоящее Время, romanized: Nastoyashcheye Vremya) is a Russian-language television channel **with editorial office in Prague, created by the US organisations Radio Free Europe/Radio Liberty and Voice of America.**