### PR TITLE
Update italy.md

### DIFF
--- a/italy.md
+++ b/italy.md
@@ -99,7 +99,6 @@ https://www.tivusat.tv/sat-eng/tivusat/multicanale.aspx
 | 0   | Bergamo Tv | [>](http://api.new.livestream.com/accounts/245066/events/3063596/live.m3u8) | <img height="20" src="https://i.imgur.com/1doR6Vl.png"/> |
 | 0   | BFC            | [>](https://backup.superstreaming.inaria.me/BFC/index.m3u8) | <img height="20" src="https://i.imgur.com/3OOsLu6.png"/> |
 | 0   | BIKE           | [>](https://backup.superstreaming.inaria.me/BikeSmartMobilityDTT/index.m3u8) | <img height="20" src="https://i.imgur.com/4IzVSQI.png"/> |
-| 262 | Byoblu Tv | [>](https://09bd1346f7a44cc9ac230cc1cb22ca4f.msvdn.net/live/S39249178/EnTK3KeeN1Eg/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KldC2gI.png"/> |
 | 0   | Cafe Tv 24 | [>](http://srv3.meway.tv:1957/cafe/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/KbcbxFw.png"/> |
 | 0   | Calabria Uno TV  | [>](https://5f22d76e220e1.streamlock.net/calabriaunotv/calabriaunotv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/2TK1GQ5.png"/> |
 | 0   | Calabria tv | [>](https://5db313b643fd8.streamlock.net:443/CalabriaTv2/CalabriaTv2/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qWirucd.png"/> |


### PR DESCRIPTION
The channel named "Byoblu Tv" breaches the policy "No channels dedicated to any particular political party".
Claudio Messora, Byoblu Tv sole proprietor and editor-in-chief, runs for a seat in the Italian Lower Chamber / Parlamento. [[0](https://www.ideawebtv.it/2022/08/04/elezioni-italia-sovrana-e-popolare-presenta-i-candidati-in-granda-porteremo-le-istanze-dei-cittadini-in-parlamento-video/)][[1](https://www.ildolomiti.it/politica/2022/dal-fondatore-di-byoblu-a-marco-rizzo-fino-ad-ingroia-ecco-chi-sono-i-candidati-trentini-per-la-lista-no-vax-anti-ue-e-anti-nato)][[2](https://www.ildenaro.it/elezioni-italia-sovrana-e-popolare-dalla-lollo-a-fulvio-grimaldi-candidati-in-tuttitalia/)][[3](https://www.torinotoday.it/politica/elezioni-politiche-25-settembre-2022/candidati-italia-sovrana-popolare-camera-senato.html)][[4](https://www.ideawebtv.it/2022/08/25/italia-sovrana-e-popolare-ammessa-alle-elezioni-ufficiali-i-candidati-cuneesi-per-camera-e-senato/)]

More broadly, Byoblu Edizioni Srls is as organization that promotes content that incites violence or hatred towards a person or group of people based on race, religion, gender identity or expression, sex, ethnicity, nationality, sexual orientation, etc., and content that promotes dangerous false or dangerous deceptive medical information that may cause offline harm or poses a direct threat to public health.