### PR TITLE
Add Danish regional and local channels

### DIFF
--- a/lists/denmark.md
+++ b/lists/denmark.md
@@ -6,3 +6,26 @@
 | 3   | DR2      Ⓖ | [>](https://drlive02texthls.akamaized.net/hls/live/2014188/drlive02text/master.m3u8) | <img height="20" src="https://i.imgur.com/b79UKYN.png"/> | DR2.dk |
 | 4   | DR Ramasjang  Ⓖ | [>](https://drlive03texthls.akamaized.net/hls/live/2014191/drlive03text/master.m3u8) | <img height="20" src="https://i.imgur.com/YD0z2mN.png"/> | DRRamasjang.dk |
 | 37   | Folketinget TV | [>](https://cdnapi.kaltura.com/p/2158211/sp/327418300/playManifest/entryId/1_24gfa7qq/protocol/https/format/applehttp/a.m3u8) | <img height="20" src="https://i.imgur.com/RqQDUzX.png"/> | TVfromtheDanishParliament.dk |
+
+<h3>Regional (TV2)</h2>
+
+https://en.wikipedia.org/wiki/TV_2_(Denmark)#Regions
+
+| #   | Channel        | Link  | Logo | EPG id |
+|:---:|:--------------:|:-----:|:----:|:------:|
+| 1   | TV Syd+ | [>](https://cdn-lt-live.tvsyd.dk/env/cluster-1-e.live.nvp1/live/hls/p/1956351/e/0_e9slj9wh/tl/main/st/0/t/rFEtaqAbdhUFGef_BNF4WQ/index-s32.m3u8) | <img height="20" src="https://i.imgur.com/k2jf591.png"/> | TVSYD.dk |
+| 2   | TV 2/Fyn | [>](https://cdn-lt-live.tv2fyn.dk/env/cluster-1-e.live.nvp1/live/hls/p/1966291/e/0_vsfrv0zm/tl/main/st/0/t/EgP1FA1D39taZFVewCa42w/index-s32.m3u8) | <img height="20" src="https://i.imgur.com/4L6AIMH.png"/> | TV2Fyn.dk |
+| 3   | TV 2/Øst | [>](https://cdn-lt-live.tveast.dk/env/cluster-1-e.live.nvp1/live/hls/p/1953381/e/0_zphj9q61/tl/main/st/0/t/THUB80e-ZMufZCE4pDhO0g/index-s32.m3u8) | <img height="20" src="https://i.imgur.com/H9l6Ulw.png"/> | TV2Ost.dk |
+| 4   | TV 2/Nord | [>](https://cdn-lt-live.tv2nord.dk/env/cluster-1-e.live.nvp1/live/hls/p/1956931/e/1_h9yfe7h2/tl/main/st/1/t/_FUn1YHQ6_P6lES4U6mmsA/index-s32.m3u8) | <img height="20" src="https://i.imgur.com/tEJ22UW.png"/> | TV2Nord.dk |
+| 5   | TV 2 Kosmopol | [>](https://cdn-lt-live.tv2lorry.dk/env/cluster-1-d.live.nvp1/live/hls/p/2045321/e/1_grusx1zd/tl/main/st/0/t/rCct87c-v2SFFCvQK1BBOg/index-s32.m3u8) | <img height="20" src="https://i.imgur.com/oVmCoKY.png"/> | TV2Kosmopol.dk |
+| 6   | TV/Midt-Vest | [>](https://cdn-lt-live.tvmidtvest.dk/env/cluster-1-d.live.frp1/live/hls/p/1953371/e/1_9x5lzos9/tl/main/st/0/t/9MTEhotxVwKuatx1EVXdGg/index-s34.m3u8) | <img height="20" src="https://i.imgur.com/OU7xIVa.png"/> | TVMidtvest.dk |
+| 7   | TV 2/Østjylland | [>](https://cdn-lt-live.tvmidtvest.dk/env/cluster-1-d.live.frp1/live/hls/p/1953371/e/1_9x5lzos9/tl/main/st/0/t/9MTEhotxVwKuatx1EVXdGg/index-s34.m3u8) | <img height="20" src="https://i.imgur.com/qEUXjHp.png"/> | TV2Ostjylland.dk |
+| 8   | TV 2/Bornholm | [>](https://live.tv2bornholm.dk/stream/live/playlist.m3u8) | <img height="20" src="https://i.imgur.com/cEOpXU6.png"/> | TV2Bornholm.dk |
+
+<h3>Local</h3>
+
+| #   | Channel        | Link  | Logo | EPG id |
+|:---:|:--------------:|:-----:|:----:|:------:|
+| 1   | TV Storbyen    | [>](https://5eeb3940cfaa0.streamlock.net/webtv_live/_definst_/mp4:kanalnordvest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/QqjRqow.png"/> | TVStorbyen.dk |
+| 2   | Kanal Hovedstaden | [>](http://khkbh.dk:8080/hls/livestream/index.m3u8) | <img height="20" src="https://i.imgur.com/MCXYDwH.png"/> | KanalHovedstaden.dk |
+| 3   | KKRtv          | [>](rtmp://video.kkr.dk/live/kkr) | <img height="20" src="https://i.imgur.com/TbtjWHI.png"/> | KKRtv.dk |


### PR DESCRIPTION
The Danish system of TV2 regional channels seems similar to ["The Third" of Germany](https://en.wikipedia.org/wiki/Television_in_Germany#Public_broadcasters), as they are broadcasting different programs each.

TV Syd: https://www.tvsyd.dk/live-tv
TV 2/Fyn: https://www.tv2fyn.dk/live-tv
TV 2/Øst: https://www.tv2east.dk/live
TV 2/Nord: https://www.tv2nord.dk/live-tv
TV 2 Kosmopol: https://www.tv2kosmopol.dk/live
TV/Midt-Vest: https://www.tvmidtvest.dk/tv-kanalen
TV 2/Østjylland: https://www.tv2ostjylland.dk/live-tv
TV 2/Bornholm: https://play.tv2bornholm.dk/?area=liveTV

TV Storbyen: http://www.kanalnordvest.dk/webtv