### PR TITLE
Add Israeli channels

### DIFF
--- a/lists/israel.md
+++ b/lists/israel.md
@@ -1,5 +1,15 @@
 <h1>Israel</h1>
 
+https://en.wikipedia.org/wiki/List_of_television_channels_in_Israel
+
 | #   | Channel        | Link  | Logo | EPG id |
 |:---:|:--------------:|:-----:|:----:|:------:|
-| 1   | Knesset        | [>](https://contact.gostreaming.tv/Knesset/myStream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/PEdXHSE.png"/> | Knesset.il |
+| 9   | 9 канал Ⓨ      | [>](https://www.youtube.com/@israel9tv/live) | <img height="20" src="https://i.imgur.com/pttM3KQ.png"/> | Channel9.il |
+| 11  | כאן 11         | [>](https://kan11.media.kan.org.il/hls/live/2024514/2024514/master.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Kan11Logo.svg/640px-Kan11Logo.svg.png"/> | Kan11.il |
+| 12  | ערוץ 12        | [x]() | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/Keshet12_2018.svg/788px-Keshet12_2018.svg.png"/> | Keshet12.il |
+| 13  | ערוץ 13        | [>](https://d2xg1g9o5vns8m.cloudfront.net/out/v1/0855d703f7d5436fae6a9c7ce8ca5075/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/he/thumb/1/17/Reshet13Logo2022.svg/559px-Reshet13Logo2022.svg.png"/> | Channel13.il |
+| 14  | ערוץ 14        | [>](https://now14.g-mana.live/media/91517161-44ab-4e46-af70-e9fe26117d2e/mainManifest.m3u8) | <img height="20" src="https://i.imgur.com/Iq2Kb69.png"/> | Now14.il |
+| 21  | The Shopping Channel | [>](https://shoppingil-rewriter.vidnt.com/index.m3u8) | <img height="20" src="https://i.imgur.com/PEdXHSE.png"/> | TheShoppingChannel.il |
+| 33  | مكان 33        | [>](https://makan.media.kan.org.il/hls/live/2024680/2024680/master.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/5/56/MeKan_33_logo_2017.png"/> | Makan33.il |
+| 99  | כאן חינוכית    | [>](https://kan23.media.kan.org.il/hls/live/2024691/2024691/master.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/KanHinuchit.svg/640px-KanHinuchit.svg.png"/> | KanEducational.il |
+| 99  | Knesset        | [>](https://contact.gostreaming.tv/Knesset/myStream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/PEdXHSE.png"/> | Knesset.il |


### PR DESCRIPTION
Keshet 12 (ערוץ 12) can be played live on: https://www.mako.co.il/mako-vod-live-tv/VOD-6540b8dcb64fd31006.htm

It needs a token to play to be played outside of a browser