### PR TITLE
Add Albanian channels

### DIFF
--- a/lists/albania.md
+++ b/lists/albania.md
@@ -13,7 +13,7 @@
 | #  | Channel        | Link  | Logo | EPG id |
 |:--:|:--------------:|:-----:|:----:|:------:|
 | 0  | A2 CNN Albania | [>](https://tv.a2news.com/live/smil:a2cnnweb.stream.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TgO3Lzi.png"/> | A2CNN.al |
-| 0  | ABC News Albania Ⓨ | [>](https://www.twitch.tv/abcnewsal) | <img height="20" src="https://i.imgur.com/aObcudw.png"/> | ABCNewsAlbania.al |
+| 0  | ABC News Albania Ⓣ | [>](https://www.twitch.tv/abcnewsal) | <img height="20" src="https://i.imgur.com/aObcudw.png"/> | ABCNewsAlbania.al |
 | 0  | AlbKanale Music TV Ⓢ | [>](https://albportal.net/albkanalemusic.m3u8) | <img height="20" src="https://i.imgur.com/JdKxscs.png"/> | AlbKanaleMusicTV.al |
 | 0  | Alpo TV | [>](https://5d00db0e0fcd5.streamlock.net/7236/7236/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Pr4ixiA.png"/> | AlpoTV.al |
 | 0  | CNA | [>](https://live1.mediadesk.al/cnatvlive.m3u8) | <img height="20" src="https://i.imgur.com/X3ukD5t.png"/> | CNA.al |
@@ -23,7 +23,7 @@
 | 0  | Panorama TV Ⓢ | [>](http://198.244.188.94/panorama/livestream/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Panorama_logo.svg/512px-Panorama_logo.svg.png"/> | PanoramaTV.al |
 | 0  | Report TV | [>](https://deb10stream.duckdns.org/hls/stream.m3u8) | <img height="20" src="https://i.imgur.com/yuRDJYY.png"/> | ReportTV.al |
 | 0  | Syri | [>](https://stream.syritv.al/SyriTV/index.m3u8) | <img height="20" src="https://i.imgur.com/4zVyj1M.png"/> | Syri.al |
-| 0  | Top News Ⓨ | [>](https://www.twitch.tv/topnewsal) | <img height="20" src="https://i.imgur.com/tBAXkOW.png"/> | TopNews.al |
+| 0  | Top News Ⓣ | [>](https://www.twitch.tv/topnewsal) | <img height="20" src="https://i.imgur.com/tBAXkOW.png"/> | TopNews.al |
 | 0  | Tropoja | [>](https://live.prostream.al/al/smil:tropojatv.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/D3hNOVS.png"/> | TropojaTelevizion.al |
 | 0  | TV 7 Albania | [>](https://5d00db0e0fcd5.streamlock.net/7064/7064/playlist.m3u8) | <img height="20" src="https://i.imgur.com/k9WqPLZ.png"/> | TV7Albania.al |
 | 0  | TV Apollon Ⓢ | [>](https://live.apollon.tv/Apollon-WEB/video.m3u8?token=tnt3u76re30d2) | <img height="20" src="https://i.imgur.com/gUz2AjM.png"/> | TVApollon.al |

--- a/lists/albania.md
+++ b/lists/albania.md
@@ -1,0 +1,30 @@
+<h1>Albania</h1>
+
+<h2>DVB-S</h2>
+
+* https://en.satexpat.com/tv/albania/
+
+| #  | Channel        | Link  | Logo | EPG id |
+|:--:|:--------------:|:-----:|:----:|:------:|
+| 0  | Kanali 7 Ⓢ | [>](https://fe.tring.al/delta/105/out/u/1200_1.m3u8) | <img height="20" src="https://i.imgur.com/rL2v9pM.png"/> | Kanali7.al |
+
+<h2>Web</h2>
+
+| #  | Channel        | Link  | Logo | EPG id |
+|:--:|:--------------:|:-----:|:----:|:------:|
+| 0  | A2 CNN Albania | [>](https://tv.a2news.com/live/smil:a2cnnweb.stream.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/TgO3Lzi.png"/> | A2CNN.al |
+| 0  | ABC News Albania Ⓨ | [>](https://www.twitch.tv/abcnewsal) | <img height="20" src="https://i.imgur.com/aObcudw.png"/> | ABCNewsAlbania.al |
+| 0  | AlbKanale Music TV Ⓢ | [>](https://albportal.net/albkanalemusic.m3u8) | <img height="20" src="https://i.imgur.com/JdKxscs.png"/> | AlbKanaleMusicTV.al |
+| 0  | Alpo TV | [>](https://5d00db0e0fcd5.streamlock.net/7236/7236/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Pr4ixiA.png"/> | AlpoTV.al |
+| 0  | CNA | [>](https://live1.mediadesk.al/cnatvlive.m3u8) | <img height="20" src="https://i.imgur.com/X3ukD5t.png"/> | CNA.al |
+| 0  | Euronews Albania Ⓨ | [>](https://www.youtube.com/@EuronewsAlbania/live) | <img height="20" src="https://i.imgur.com/Skf6vdi.png"/> | EuronewsAlbania.al |
+| 0  | News 24 Ⓢ | [>](https://tv.balkanweb.com/news24/livestream/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2d/News_24_%28Albania%29.svg/1024px-News_24_%28Albania%29.svg.png"/> | News24.al |
+| 0  | Ora News | [>](https://live1.mediadesk.al/oranews.m3u8) | <img height="20" src="https://i.imgur.com/ILZY5bJ.png"/> | OraNews.al |
+| 0  | Panorama TV Ⓢ | [>](http://198.244.188.94/panorama/livestream/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Panorama_logo.svg/512px-Panorama_logo.svg.png"/> | PanoramaTV.al |
+| 0  | Report TV | [>](https://deb10stream.duckdns.org/hls/stream.m3u8) | <img height="20" src="https://i.imgur.com/yuRDJYY.png"/> | ReportTV.al |
+| 0  | Syri | [>](https://stream.syritv.al/SyriTV/index.m3u8) | <img height="20" src="https://i.imgur.com/4zVyj1M.png"/> | Syri.al |
+| 0  | Top News Ⓨ | [>](https://www.twitch.tv/topnewsal) | <img height="20" src="https://i.imgur.com/tBAXkOW.png"/> | TopNews.al |
+| 0  | Tropoja | [>](https://live.prostream.al/al/smil:tropojatv.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/D3hNOVS.png"/> | TropojaTelevizion.al |
+| 0  | TV 7 Albania | [>](https://5d00db0e0fcd5.streamlock.net/7064/7064/playlist.m3u8) | <img height="20" src="https://i.imgur.com/k9WqPLZ.png"/> | TV7Albania.al |
+| 0  | TV Apollon Ⓢ | [>](https://live.apollon.tv/Apollon-WEB/video.m3u8?token=tnt3u76re30d2) | <img height="20" src="https://i.imgur.com/gUz2AjM.png"/> | TVApollon.al |
+| 0  | Vizion Plus | [>](https://fe.tring.al/delta/105/out/u/rdghfhsfhfshs.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Vizion_Plus.svg/512px-Vizion_Plus.svg.png"/> | VizionPlus.al |


### PR DESCRIPTION
List of livestream addresses:

* https://a2news.com/live/
* https://abcnews.al/live/
* https://albportal.net/
* https://alpomedia.com/live/
* https://www.cna.al/
* https://euronews.al/en/live
* https://www.balkanweb.com/
* http://www.panorama.com.al/tv/index1.php
* https://www.oranews.tv/live/
* https://www.report-tv.al/report_live
* https://www.syri.net/
* https://top-channel.tv/topnewslive/
* https://tropoja.tv/live/
* https://tv7.al/live/
* https://apollon.tv/
* https://www.vizionplus.tv/livestream/