### PR TITLE
Update zz_news_en.md

### DIFF
--- a/lists/zz_news_en.md
+++ b/lists/zz_news_en.md
@@ -2,10 +2,35 @@
 
 | #   | Channel        | Link  | Logo | EPG id |
 |:---:|:--------------:|:-----:|:----:|:------:|
-| 1   | SkyNews English    | [>](https://i.mjh.nz/PlutoTV/55b285cd2665de274553d66f-alt.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/thumb/5/57/Sky_News_logo.svg/512px-Sky_News_logo.svg.png"/> | SkyNewsInternational.uk |
-| 2   | Euronews English | [>](https://rakuten-euronews-1-gb.samsung.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Euronews_2022.svg/640px-Euronews_2022.svg.png"/> | EuronewsEnglish.fr |
-| 3   | Africanews English Ⓨ | [>](https://www.youtube.com/c/africanews/live) | <img height="20" src="https://i.imgur.com/xocvePC.png"/> | Africanews.cg |
-| 4   | France 24 English Ⓨ | [>](https://www.youtube.com/c/FRANCE24English/live) | <img height="20" src="https://i.imgur.com/61MSiq9.png"/> | France24English.fr |
-| 5   | DW English  | [>](https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/index.m3u8) | <img height="20" src="https://i.imgur.com/A1xzjOI.png"/> | DWEnglish.de |
-| 6   | Al Jazeera English   | [>](https://live-hls-web-aje.getaj.net/AJE/index.m3u8) | <img height="20" src="https://i.imgur.com/BB93NQP.png"/> | AlJazeeraEnglish.qa |
-| 7   | CGTN English         | [>](https://news.cgtn.com/resource/live/english/cgtn-news.m3u8) | <img height="20" src="https://i.imgur.com/fMsJYzl.png"/> | CGTN.cn |
+| 1   | Sky News   | [>](https://i.mjh.nz/PlutoTV/55b285cd2665de274553d66f-alt.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/thumb/5/57/Sky_News_logo.svg/512px-Sky_News_logo.svg.png"/> | SkyNewsInternational.uk |
+| 2   | Euronews | [>](https://shls-live-ak.akamaized.net/out/v1/115bfcde8fa342d182ef846445cdbdcf/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Euronews_2022.svg/640px-Euronews_2022.svg.png"/> | EuronewsEnglish.fr |
+| 3   | Africanews | [>](https://ythls.armelin.one/channel/UC1_E8NeF5QHY2dtdLRBCCLA.m3u8) | <img height="20" src="https://i.imgur.com/xocvePC.png"/> | Africanews.cg |
+| 4   | France 24 | [>](http://92.114.85.80:8000/play/a03l) | <img height="20" src="https://i.imgur.com/61MSiq9.png"/> | France24English.fr |
+| 5   | DW  | [>](https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/index.m3u8) | <img height="20" src="https://i.imgur.com/A1xzjOI.png"/> | DWEnglish.de |
+| 6   | Al Jazeera   | [>](https://live-hls-web-aje.getaj.net/AJE/index.m3u8) | <img height="20" src="https://i.imgur.com/BB93NQP.png"/> | AlJazeeraEnglish.qa |
+| 7   | CGTN          | [>](https://news.cgtn.com/resource/live/english/cgtn-news.m3u8) | <img height="20" src="https://i.imgur.com/fMsJYzl.png"/> | CGTN.cn |
+| 8   | BBC News             | [>](http://92.114.85.81:8000/play/a00a/index.m3u8) | <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-kingdom/bbc-news-uk.png"/> | BBCNews.uk |
+| 9   | NBC News NOW         | [>](https://i.mjh.nz/SamsungTVPlus/GBBB1500004LG.m3u8) | <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-kingdom/nbc-news-now-uk.png"/> | NBCNewsNOW.us |
+| 10  | Reuters              | [>](https://i.mjh.nz/SamsungTVPlus/GBBA33000219V.m3u8) | <img height="20" src="https://i.imgur.com/6eQ2nCJ.png"/> | ReutersTV.us |
+| 11  | The Guardian         | [>](https://i.mjh.nz/SamsungTVPlus/GBAJ2400003DD.m3u8) | <img height="20" src="https://i.imgur.com/o9AYq9V.png"/> | TheGuardian.uk |
+| 12  | CBS News             | [>](https://i.mjh.nz/SamsungTVPlus/USBA370000104.m3u8) | <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-states/cbs-news-us.png"/> | CBSNews.us |
+| 13  | ABC News Live        | [>](https://i.mjh.nz/SamsungTVPlus/USBC39000171G.m3u8) | <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-states/abc-news-live-hz-us.png"/> | ABCNewsLive.us |
+| 14  | LiveNOW from FOX     | [>](https://i.mjh.nz/SamsungTVPlus/USBA300024TN.m3u8)  | <img height="20" src="https://i.imgur.com/1JnyzHv.png"/> | LiveNOWFromFOX.us |
+| 15  | CBC News Network     | [>](https://dai2.xumo.com/amagi_hls_data_xumo1212A-redboxcbcnews/CDN/playlist.m3u8) | <img height="20" src="https://i.imgur.com/SjTdhvJ.png"/> | CBCNewsNetwork.ca |
+| 16  | Ticker News          | [>](https://cdn-uw2-prod.tsv2.amagi.tv/linear/amg01486-tickernews-tickernewsweb-ono/playlist.m3u8) | <img height="20" src="https://i.imgur.com/z7M0QxV.png"/> | tickerNews.au |
+| 17  | India Today          | [>](https://indiatodaylive.akamaized.net/hls/live/2014320/indiatoday/indiatodaylive/playlist.m3u8) | <img height="20" src="https://i.imgur.com/koFYddE.png"/> | IndiaToday.in |
+| 18  | Channel News Asia    | [>](https://ythls.armelin.one/channel/UC83jt4dlz1Gjl58fzQrrKZg.m3u8) | <img height="20" src="https://i.imgur.com/xWglicB.png"/> | CNAInternational.sg |
+| 19  | ABC News (AU)        | [>](https://ythls.armelin.one/channel/UCVgO39Bk5sMo66-6o6Spn6Q.m3u8) | <img height="20" src="https://i.imgur.com/BrW7gk8.png"/> | ABCNews.au |
+| 20  | NDTV 24x7            | [>](https://ythls.armelin.one/channel/UCZFMm1mMw0F81Z37aaEzTUA.m3u8) | <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/india/ndtv-24x7-in.png"/> | NDTV24x7.in |
+| 21  | TRT World            | [>](https://ythls.armelin.one/channel/UC7fWeaHhqgM4Ry-RMpM2YYw.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/512px-TRT_World.svg.png"/> | TRTWorld.tr |
+| 22  | NHK World Japan      | [>](https://ythls.armelin.one/channel/UCSPEjw8F2nQDtmUKPFNF7_A.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/NHK_World-Japan_TV.svg/512px-NHK_World-Japan_TV.svg.png"/> | NHKWorldJapan.jp |
+| 23  | DD India             | [>](https://ythls.armelin.one/channel/UCGDQNvybfDDeGTf4GtigXaw.m3u8) | <img height="20" src="https://i.imgur.com/45uptR8.png"/> | DDIndia.in |
+| 24  | WION                 | [>](https://ythls.armelin.one/channel/UC_gUM8rL-Lrg6O3adPW9K1g.m3u8) | <img height="20" src="https://i.imgur.com/Wc5Z3iS.png"/> | WION.in |
+| 25  | Taiwan+              | [>](https://ythls.armelin.one/channel/UC7c6rvyAZLpKGk8ttVnpnLA.m3u8) | <img height="20" src="https://i.imgur.com/SfcZyqm.png"/> | TaiwanPlusTV.tw |
+| 26  | Metro Globe Network  | [>](https://edge.medcom.id/live-edge/smil:mgnch.smil/playlist.m3u8)  | <img height="20" src="https://i.imgur.com/aiiinzg.png"/> | MetroGlobeNetwork.id |
+| 27  | i24 News             | [>](https://bcovlive-a.akamaihd.net/6e3dd61ac4c34d6f8fb9698b565b9f50/eu-central-1/5377161796001/playlist-all_dvr.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/LOGO_i24NEWS.png/512px-LOGO_i24NEWS.png"/> | i24NEWSEnglishWorld.il |
+| 28  | Scripps News         | [>](https://content.uplynk.com/channel/4bb4901b934c4e029fd4c1abfc766c37.m3u8) | <img height="20" src="https://i.imgur.com/UfN6aAi.png"/> | ScrippsNews.us |
+| 29  | USA Today            | [>](https://lnc-usa-today.tubi.video/playlist.m3u8) | <img height="20" src="https://i.imgur.com/37K0AZX.png"/> | USATODAY.us |
+| 101  | Cheddar News         | [>](https://cheddar-cheddar-3.roku.wurl.com/manifest/playlist.m3u8) | <img height="20" src="https://i.imgur.com/tuP9GW8.png"/> | CheddarNews.us |
+| 102  | Bloomberg TV+        | [>](https://bloomberg.com/media-manifest/streams/phoenix-us.m3u8) | <img height="20" src="https://i.imgur.com/xGlToly.png"/> | BloombergTVPlus.us |
+| 103  | CNBC HD              | [>](http://92.114.85.77:8000/play/a0b6) | <img height="20" src="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1088.png"/> | CNBCEurope.uk |


### PR DESCRIPTION
Additions:
- BBC News (Not geo-blocked)
- NBC News Now (from Samsung TV Plus)
- Reuters (from Samsung TV Plus)
- The Guardian (from Samsung TV Plus)
- CBS News (from Samsung TV Plus)
- ABC News Live (from Samsung TV Plus)
- LiveNOW from FOX (from Samsung TV Plus)
- CBC News Network (from Xumo)
- Ticker News
- India Today
- CNA (Channel News Asia) (YouTube via ythls.armelin.one)
- ABC News (the Australia one) (YouTube via ythls.armelin.one)
- NDTV 24x7 (YouTube via ythls.armelin.one)
- TRT World (YouTube via ythls.armelin.one)
- NHK World Japan  (YouTube via ythls.armelin.one)
- DD India (YouTube via ythls.armelin.one)
- WION (YouTube via ythls.armelin.one)
- Taiwan+ (YouTube via ythls.armelin.one)
- Metro Globe Network
- i24 NEWS
- Scripps News
- USA Today
- Cheddar News, Bloomberg+ TV and CNBC Europe as a kind of 'business section'

Changes:
- Rename Sky News
- Rename Euronews and fix broken stream
- Convert Africanews to use ythls.armelin.one
- Rename France24, convert to a live stream
- Rename DW
- Rename Al Jazeera
- Rename CGTN

Notes:
More than happy to add the (Y) symbol to the ones using ythls.armelin.one as they are sourced from YouTube, but can be played straight away in a video player/IPTV app.