### PR TITLE
Remove broken links for Macedonian channels

### DIFF
--- a/lists/north_macedonia.md
+++ b/lists/north_macedonia.md
@@ -4,42 +4,21 @@
 
 | #   | Channel        | Link  | Logo | EPG id |
 |:---:|:--------------:|:-----:|:----:|:------:|
-| 1   | MRT1 Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(MRT_1)/index.m3u8) | <img height="20" src="https://i.imgur.com/EkkyAE0.png"/> | MRT1.mk |
-| 2   | MRT2 Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(MRT_2)/index.m3u8) | <img height="20" src="https://i.imgur.com/YvOrUnN.png"/> | MRT2.mk |
-| 3   | MRT Sobraniski kanal Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Sobraniski_Kanal)/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Logo_of_MRT_Assembly_Channel_%282012-%29.svg/634px-Logo_of_MRT_Assembly_Channel_%282012-%29.svg.png"/> | MRTSobraniskikanal.mk |
-| 3   | MRT3 Ⓖ | [>](https://www.tvkaista.net/stream-forwarder/get.php?x=MRT3) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Logo_of_MRT_3_%282020-%29.svg/640px-Logo_of_MRT_3_%282020-%29.svg.png"/> | MRT3.mk |
-| 4   | MRT4 Ⓖ | [>](https://www.tvkaista.net/stream-forwarder/get.php?x=MRT4) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Logo_of_MRT_4_%282020-%29.svg/640px-Logo_of_MRT_4_%282020-%29.svg.png"/> | MRT4.mk |
-| 4   | MRT5 Ⓖ | [>](https://www.tvkaista.net/stream-forwarder/get.php?x=MRT5) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Logo_of_MRT_5_%282020-%29.svg/640px-Logo_of_MRT_5_%282020-%29.svg.png"/> | MRT5.mk |
-| 5   | Kanal 5 Ⓢ Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Kanal_5)/index.m3u8) | <img height="20" src="https://i.imgur.com/Qw7N3S2.png"/> | Kanal5.mk |
-| 28  | Alfa TV Ⓢ Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Alfa)/index.m3u8) | <img height="20" src="https://i.imgur.com/5BSyXfr.png"/> | AlfaTV.mk |
-| 100 | Alsat M Ⓢ Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Alsat_M)/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Logo_of_Alsat_TV_%282020-%29.svg/640px-Logo_of_Alsat_TV_%282020-%29.svg.png"/> | Alsat.mk |
-| 101 | Sitel Ⓢ Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Sitel)/index.m3u8) | <img height="20" src="https://i.imgur.com/pdobwKt.png"/> | Sitel.mk |
-| 102 | Telma Ⓢ Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Telma)/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Logo_of_Telma_%282016-%29.svg/497px-Logo_of_Telma_%282016-%29.svg.png"/> | TelmaTV.mk |
 
-<h2>DVB-S</h2>
 
-| #   | Channel        | Link  | Logo | EPG id |
-|:---:|:--------------:|:-----:|:----:|:------:|
-| 1   | MRT Sat   | [>](https://www.tvkaista.net/stream-forwarder/get.php?x=MRT1Sat) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Logo_of_MRT_SAT_%282012-%29.svg/640px-Logo_of_MRT_SAT_%282012-%29.svg.png"/> | MRT1Sat.mk |
-| 2   | MRT 2 Sat | [>](https://www.tvkaista.net/stream-forwarder/get.php?x=MRT2Sat) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Logo_of_MRT_2_SAT_%282012-%29.svg/640px-Logo_of_MRT_2_SAT_%282012-%29.svg.png"/> | MRT2Sat.mk |
-| 3   | TV 21 Ⓢ Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(TV21)/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Logo_of_TV21_Macedonia.svg/640px-Logo_of_TV21_Macedonia.svg.png"/> | TV21.mk |
 
 <h2>DVB-C</h2>
 
 | #   | Channel        | Link  | Logo | EPG id |
 |:---:|:--------------:|:-----:|:----:|:------:|
 | 1 | Телевизија Здравкин | [>](http://zdravkin.hugo.mk:1935/live/zdravkin/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kSmcAER.png"/> | Zdravkin |
-| 2 | ТВ Сонце | [>](https://media2.streambrothers.com:1936/8142/8142/playlist.m3u8) | <img height="20" src="https://i.imgur.com/LblSsIv.png"/> | tv-sonce.com |
 | 3 | Орбис | [>](http://tvorbis.hugo.mk:1935/live/orbistv/index.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/6/6f/Orbis-logo.png"/> | TV Orbis |
 | 4 | M»Net | [>](http://ares.mnet.mk/hls/mnet.m3u8) | <img height="20" src="https://i.imgur.com/JWHcGMX.png"/> | mnet.mk |
-| 5 | Македонско Сонце | [>](https://media2.streambrothers.com:1936/8128/8128/playlist.m3u8) | <img height="20" src="https://i.imgur.com/b97qVaV.png"/> | makedonsko-sonce |
 | 6 | Канал 8 | [>](http://kanal8.hugo.mk:1935/live/kanal8/index.m3u8) | <img height="20" src="https://i.imgur.com/5skC7be.png"/> | kanal8.mk |
 | 7 | ТВ СВЕТ | [>](http://tvsvet.hugo.mk:1936/live/tvsvet/stream/3.m3u8) | <img height="20" src="https://i.imgur.com/R79xT60.png"/> | tvsvet.com.mk |
 | 8 | M»Net Sport | [>](http://ares.mnet.mk/hls/mnet-sport.m3u8) | <img height="20" src="https://i.imgur.com/q3DV2gP.png"/> | sport.mnet.mk |
 | 9 | M»Net Info | [>](http://ares.mnet.mk/hls/mnet-info.m3u8) | <img height="20" src="https://i.imgur.com/O26HEyC.png"/> | info.mnet.mk |
-| 10 | MTM 1 Скопска Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(MTM)/index.m3u8) | <img height="20" src="https://i.imgur.com/w6Uy2Zd.png"/> | mtm.mk |
 | 11 | TV 24 Ⓖ | [>](https://hls.telekabel.com.mk:1936/live/11/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MFKeNZx.png"/> | 24.mk |
-| 12 | B1 Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Shutel)/index.m3u8) | <img height="20" src="https://i.imgur.com/UgUpZ2M.png"/> | b1 |
 | 13 | M»Net Kids | [>](http://ares.mnet.mk/hls/mnet-kids.m3u8) | <img height="20" src="https://i.imgur.com/XZwtu7Q.png"/> | kids.mnet.mk |
 
 <h2>Web</h2>

--- a/lists/north_macedonia.md
+++ b/lists/north_macedonia.md
@@ -38,7 +38,7 @@
 | 8 | M»Net Sport | [>](http://ares.mnet.mk/hls/mnet-sport.m3u8) | <img height="20" src="https://i.imgur.com/q3DV2gP.png"/> | sport.mnet.mk |
 | 9 | M»Net Info | [>](http://ares.mnet.mk/hls/mnet-info.m3u8) | <img height="20" src="https://i.imgur.com/O26HEyC.png"/> | info.mnet.mk |
 | 10 | MTM 1 Скопска Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(MTM)/index.m3u8) | <img height="20" src="https://i.imgur.com/w6Uy2Zd.png"/> | mtm.mk |
-| 11 | TV 24 Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(TV_24)/index.m3u8) | <img height="20" src="https://i.imgur.com/MFKeNZx.png"/> | 24.mk |
+| 11 | TV 24 Ⓖ | [>](https://hls.telekabel.com.mk:1936/live/11/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MFKeNZx.png"/> | 24.mk |
 | 12 | B1 Ⓖ | [>](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Shutel)/index.m3u8) | <img height="20" src="https://i.imgur.com/UgUpZ2M.png"/> | b1 |
 | 13 | M»Net Kids | [>](http://ares.mnet.mk/hls/mnet-kids.m3u8) | <img height="20" src="https://i.imgur.com/XZwtu7Q.png"/> | kids.mnet.mk |
 


### PR DESCRIPTION
Summary:
- One of the telecom providers decided to shut down their free iptv service. This caused a loss of many channels. 😢
- The proxy service from @TVKaista seems to be down, so I removed those channels too.
- Sonce and Makedonsko sonce channels have moved to rumble. The old links don't work anymore and have been removed as well. 