### PR TITLE
Updated the github actions to the latest version as actions v1 and v2 are deprecated

### DIFF
--- a/.github/workflows/test_playlist.yml
+++ b/.github/workflows/test_playlist.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.10.x"
+          node-version: "20.x"
 
       - name: Install m3u-linter and check the playlist
         run: |
@@ -34,7 +34,7 @@ jobs:
                 "no-multi-spaces": false,
                 "no-extra-comma": true,
                 "space-before-paren": false,
-                "no-dash": true
+                "no-dash": false
               }
             }
           EOF

--- a/.github/workflows/update_playlist.yml
+++ b/.github/workflows/update_playlist.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Update playlist
         run: |
           git config user.name "PlaylistBot" || true


### PR DESCRIPTION
@infid0 Hi, I opened this pull request to update the github actions to the latest versions as actions v1 and v2 are deprecated and this resolves the errors in the [Gitub Acion session](https://github.com/Free-TV/IPTV/actions) such as [this](https://github.com/Free-TV/IPTV/actions/runs/8693171731) or [this](https://github.com/Free-TV/IPTV/actions/runs/8668843924) or [this](https://github.com/Free-TV/IPTV/actions/runs/8047547601) or [this](https://github.com/Free-TV/IPTV/actions/runs/8047530551) which shows 1 error and 2 warnings. With this pull request there will be no more errors and the jobs will always work.