### PR TITLE
Update czech_republic.md

### DIFF
--- a/lists/czech_republic.md
+++ b/lists/czech_republic.md
@@ -2,13 +2,10 @@
 
 | #   | Channel        | Link  | Logo | EPG id |
 |:---:|:--------------:|:-----:|:----:|:------:|
-| 1   | ČT1 Ⓖ    | [>](https://sktv-forwarders.7m.pl/get.php?x=CT1) | <img height="20" src="https://i.imgur.com/qBlEbN3.png"/> | CT1.cz |
-| 2   | ČT2 Ⓖ    | [>](https://sktv-forwarders.7m.pl/get.php?x=CT2) | <img height="20" src="https://i.imgur.com/HpnGC6A.png"/> | CT2.cz |
-| 3   | ČT24      | [>](https://sktv-forwarders.7m.pl/get.php?x=CT24) | <img height="20" src="https://i.imgur.com/pUMRFs1.png"/> | CT24.cz |
-| 4   | ČT sport Ⓖ    | [>](https://sktv-forwarders.7m.pl/get.php?x=CTsport) | <img height="20" src="https://i.imgur.com/I2dltZW.png"/> | CTSport.cz |
-| 5   | ČT :D      | [>](https://sktv-forwarders.7m.pl/get.php?x=CT_D) | <img height="20" src="https://i.imgur.com/Pa5rLpA.png"/> | CTDecko.cz |
-| 6   | ČT art      | [>](https://sktv-forwarders.7m.pl/get.php?x=CTart) | <img height="20" src="https://i.imgur.com/u8mfETB.png"/> | CTart.cz |
-| 7   | ČT sport Plus Ⓖ    | [>](https://sktv-forwarders.7m.pl/get.php?x=CTsportPlus) | <img height="20" src="https://i.imgur.com/5JiMynW.png"/> | |
+| 1   | ČT1 Ⓖ    | [>](http://88.212.7.10/live/test_ct1_25p/playlist.m3u8) | <img height="20" src="https://i.imgur.com/qBlEbN3.png"/> | CT1.cz |
+| 2   | ČT2 Ⓖ    | [>](http://88.212.7.10/live/test_ct2_25p/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HpnGC6A.png"/> | CT2.cz |
+| 3   | ČT24      | [>](http://88.212.7.10/live/test_ct24_hevc/playlist.m3u8) | <img height="20" src="https://i.imgur.com/pUMRFs1.png"/> | CT24.cz |
+| 4   | ČT sport Ⓖ    | [>](http://88.212.7.10/live/test_ct24_hevc/playlist.m3u8) | <img height="20" src="https://i.imgur.com/I2dltZW.png"/> | CTSport.cz |
 | 8   | JOJ Family Ⓢ    | [>](https://live.cdn.joj.sk/live/hls/family-540.m3u8) | <img height="20" src="https://i.imgur.com/IZHIAAj.png"/> | JojFamily.sk |
 | 9   | Šlágr Originál Ⓢ    | [>](https://stream-6.mazana.tv/slagr.m3u) | <img height="20" src="https://i.imgur.com/fQcx9S2.png"/> | SlagrOriginal.cz |
 | 10  | Šlágr Muzika Ⓢ    | [>](https://stream-33.mazana.tv/slagr2.m3u) | <img height="20" src="https://i.imgur.com/J9YHDVS.png"/> | SlagrMuzika.cz |
@@ -28,3 +25,12 @@
 | 24  | Retro Music Television Ⓢ    | [>](https://stream.mediawork.cz/retrotv/smil:retrotv2.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a6S2Yo4.png"/> | RetroMusicTV.cz |
 | 25  | TN Live      | [>](https://sktv-forwarders.7m.pl/get.php?x=NovaTNLive) | <img height="20" src="https://i.imgur.com/9P7ZyFu.png"/> | |
 | 26  | Praha TV      | [>](https://stream.polar.cz/prahatv/prahatvlive-1/playlist.m3u8) | <img height="20" src="https://www.praga2018.cz/wp-content/uploads/logo-prahatv.png"/> | PrahaTV.cz |
+
+
+<h1>Invalid</h1>
+
+| #   | Channel        | Link  | Logo | EPG id |
+|:---:|:--------------:|:-----:|:----:|:------:|
+| 5   | ČT :D      | [x](https://sktv-forwarders.7m.pl/get.php?x=CT_D) | <img height="20" src="https://i.imgur.com/Pa5rLpA.png"/> | CTDecko.cz |
+| 6   | ČT art      | [x](https://sktv-forwarders.7m.pl/get.php?x=CTart) | <img height="20" src="https://i.imgur.com/u8mfETB.png"/> | CTart.cz |
+| 7   | ČT sport Plus Ⓖ    | [x](https://sktv-forwarders.7m.pl/get.php?x=CTsportPlus) | <img height="20" src="https://i.imgur.com/5JiMynW.png"/> | |


### PR DESCRIPTION
Updated links for ČT 1, ČT 2, ČT 24 and ČT Sport. Moved ČT :D, ČT art and ČT Sport Plus to invalid due to sktv-forwarders web not available.