### PR TITLE
Update brazil.md

### DIFF
--- a/lists/brazil.md
+++ b/lists/brazil.md
@@ -6,7 +6,7 @@
 | 2   | COM Brasil | [>](https://br5093.streamingdevideo.com.br/abc/abc/playlist.m3u8) | <img height="20" src="https://i.imgur.com/c8ztQnF.png"/> | COMBrasil.br |
 | 3   | CNN Brasil Ⓢ   | [x](https://streaming.cnnbrasil.com.br/cnndigital_main.m3u8) | <img height="20" src="https://i.imgur.com/FYdDmO1.png"/> | CNNBrasil.br |
 | 4   | SBT Ⓨ | [>](https://www.youtube.com/watch?v=ABVQXgr2LW4) | <img height="20" src="https://logodownload.org/wp-content/uploads/2013/12/sbt-logo.png"/> | SBTNacional.br |
-| 5   | AgroBrasil TV | [>](http://45.162.230.234:1935/agrobrasiltv/agrobrasiltv/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/pt/6/60/Logo_AgroBrasilTV.jpg"/> | AgroBrasilTV.br |
+| 5   | AgroBrasil TV | [x](http://45.162.230.234:1935/agrobrasiltv/agrobrasiltv/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/pt/6/60/Logo_AgroBrasilTV.jpg"/> | AgroBrasilTV.br |
 | 6   | Futura | [>](https://tv.unisc.br/hls/test.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/pt/d/d9/Logo-futura-horizontal.png"/> | CanalFutura.br |
 | 7   | Record | [x](https://playplusmao-lh.akamaihd.net/i/pp_mao@409195/master.m3u8) | <img height="20" src="https://i.imgur.com/TD6ZJoa.png"/> | RecordTV.br |
 | 8   | RBC | [>](http://rbc.directradios.com:1935/rbc/rbc/live.m3u8) | <img height="20" src="https://portal.rbc1.com.br/public/portal/img/layout/logorbc.png"/> |

--- a/lists/brazil.md
+++ b/lists/brazil.md
@@ -13,7 +13,7 @@
 | 9   | Anime TV | [>](https://stmv1.srvif.com/animetv/animetv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/fuuv2uP.jpg"/> | AnimeTV.br |
 | 10  | Record News | [>](https://stream.ads.ottera.tv/playlist.m3u8?network_id=2116) | <img height="20" src="https://upload.wikimedia.org/wikipedia/pt/c/c7/Logotipo_da_Record_News_%282016%29.png"/> | RecordNews.br |
 | 11  | ISTV | [>](https://video08.logicahost.com.br/istvnacional/srt.stream/istvnacional.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/pt/b/b5/Logotipo_da_ISTV.png"/> | ISTVHD.br |
-| 12  | Rede Brasil | [>](https://video01.logicahost.com.br/redebrasil02/redebrasil02/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/d/d1/Marca_rede_brasil_rgb-color.png"/> | RedeBrasil.br |
+| 12  | Rede Brasil | [>](https://video09.logicahost.com.br/redebrasiloficial/redebrasiloficial/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/d/d1/Marca_rede_brasil_rgb-color.png"/> | RedeBrasil.br |
 | 13  | TV Câmara | [>](https://stream3.camara.gov.br/tv1/manifest.m3u8) | <img height="20" src="https://i.imgur.com/UpV2PRk.png"/> | TVCamara.br |
 | 14  | TVE RS | [>](http://selpro1348.procergs.com.br:1935/tve/stve/playlist.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/c/c2/Logotipo_da_TVE_RS.png"/> |
 | 15  | Fora Tedio TV | [x](http://stream.foratedio.com/foratedio/foratedio/playlist.m3u8) | <img height="20" src="https://play.foratedio.com/img/foratedio-watermark.png"/> |


### PR DESCRIPTION
- Updated RedeBrasil.br stream link
- Disabled AgroBrasil.tv - Stream now uses [Restreamer](https://github.com/datarhei/restreamer) and works only inside a browser