### PR TITLE
Mark browser-only urls as invalid

### DIFF
--- a/lists/finland.md
+++ b/lists/finland.md
@@ -6,22 +6,22 @@
 |:---:|:--------------:|:-----:|:----:|:------:|
 | 1   | Yle TV1 Ⓖ | [>](https://yletv.akamaized.net/hls/live/622365/yletv1fin/index.m3u8) | <img height="20" src="https://i.imgur.com/6yXZwUL.png"/> | YleTV1.fi |
 | 2   | Yle TV2 Ⓖ | [>](https://yletv.akamaized.net/hls/live/622366/yletv2fin/index.m3u8) | <img height="20" src="https://i.imgur.com/4xkc6PL.png"/> | YleTV2.fi |
-| 3   | MTV3 | [>](https://live-fi.tvkaista.net/mtv3/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/kNbmc8n.png"/> | MTV3.fi |
-| 4   | Nelonen | [>](https://live-fi.tvkaista.net/nelonen/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/BFbCyfY.png"/> | Nelonen.fi |
+| 3   | MTV3 | [x](https://live-fi.tvkaista.net/mtv3/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/kNbmc8n.png"/> | MTV3.fi |
+| 4   | Nelonen | [x](https://live-fi.tvkaista.net/nelonen/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/BFbCyfY.png"/> | Nelonen.fi |
 | 5   | Yle Teema Fem Ⓖ | [>](https://yletv.akamaized.net/hls/live/622367/yletvteemafemfin/index.m3u8) | <img height="20" src="https://i.imgur.com/iDljufz.png"/> | YleTeemaFem.fi |
-| 6   | MTV Sub | [>](https://live-fi.tvkaista.net/sub/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/VRCuxQt.png"/> | Sub.fi |
-| 7   | TV5 Finland | [>](https://live-fi.tvkaista.net/tv5/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/MoukyGs.png"/> | TV5.fi |
-| 8   | Liv | [>](https://live-fi.tvkaista.net/liv/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/0/06/Liv_color_RGB.png"/> | Liv.fi |
-| 9   | Jim | [>](https://live-fi.tvkaista.net/jim/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/9/92/Jim_color_RGB.png"/> | Jim.fi |
-| 10  | Kutonen | [>](https://live-fi.tvkaista.net/kutonen/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/4giVyxb.png"/> | Kutonen.fi |
-| 11  | TLC Finland | [>](https://live-fi.tvkaista.net/tlc/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/0d5hP3A.png"/> | TLCFinland.fi |
-| 12  | Star Channel Finland | [>](https://live-fi.tvkaista.net/star-channel/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/Star_Channel_2020.svg/640px-Star_Channel_2020.svg.png"/> | StarChannel.fi |
-| 13  | MTV Ava | [>](https://live-fi.tvkaista.net/ava/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/rtyJVgB.png"/> | AVA.fi |
-| 14  | Hero | [>](https://live-fi.tvkaista.net/hero/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/b/bd/Hero_color_RGB.png"/> | Hero.fi |
-| 15  | Frii | [>](https://live-fi.tvkaista.net/frii/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/ljKoG9I.png"/> | Frii.fi |
+| 6   | MTV Sub | [x](https://live-fi.tvkaista.net/sub/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/VRCuxQt.png"/> | Sub.fi |
+| 7   | TV5 Finland | [x](https://live-fi.tvkaista.net/tv5/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/MoukyGs.png"/> | TV5.fi |
+| 8   | Liv | [x](https://live-fi.tvkaista.net/liv/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/0/06/Liv_color_RGB.png"/> | Liv.fi |
+| 9   | Jim | [x](https://live-fi.tvkaista.net/jim/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/9/92/Jim_color_RGB.png"/> | Jim.fi |
+| 10  | Kutonen | [x](https://live-fi.tvkaista.net/kutonen/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/4giVyxb.png"/> | Kutonen.fi |
+| 11  | TLC Finland | [x](https://live-fi.tvkaista.net/tlc/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/0d5hP3A.png"/> | TLCFinland.fi |
+| 12  | Star Channel Finland | [x](https://live-fi.tvkaista.net/star-channel/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/Star_Channel_2020.svg/640px-Star_Channel_2020.svg.png"/> | StarChannel.fi |
+| 13  | MTV Ava | [x](https://live-fi.tvkaista.net/ava/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/rtyJVgB.png"/> | AVA.fi |
+| 14  | Hero | [x](https://live-fi.tvkaista.net/hero/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/b/bd/Hero_color_RGB.png"/> | Hero.fi |
+| 15  | Frii | [x](https://live-fi.tvkaista.net/frii/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/ljKoG9I.png"/> | Frii.fi |
 | 16  | IRR-TV | [>](https://irrtv.digitacdn.net/live/_definst_/irrtv/amlst:irrtv.amlst/playlist.m3u8?organizationId=229401409&suiteItemId=230439940) | <img height="20" src="https://upload.wikimedia.org/wikipedia/fi/9/93/IRR-TV-1.png"/> | IRRTV.fi |
-| 17  | TapahtumaTV Eveo | [>](https://live-fi.tvkaista.net/tapahtumatv-eveo/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/sR8nA8w.png"/> | Eveo.fi |
-| 20  | National Geographic Finland | [>](https://live-fi.tvkaista.net/national-geographic/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Natgeologo.svg/512px-Natgeologo.svg.png"/> | NationalGeographicFinland.fi |
+| 17  | TapahtumaTV Eveo | [x](https://live-fi.tvkaista.net/tapahtumatv-eveo/live.m3u8?src=freetv) | <img height="20" src="https://i.imgur.com/sR8nA8w.png"/> | Eveo.fi |
+| 20  | National Geographic Finland | [x](https://live-fi.tvkaista.net/national-geographic/live.m3u8?src=freetv) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Natgeologo.svg/512px-Natgeologo.svg.png"/> | NationalGeographicFinland.fi |
 | 33  | OnniTV | [>](https://kotitv.digitacdn.net/amlst:kotitv.amlst/playlist.m3u8?organizationId=83459409&suiteItemId=83459780) | <img height="20" src="https://i.imgur.com/HzILf2H.png"/> | KotiTV.fi |
 | 45  | Taivas TV7 | [>](https://vod.tv7.fi/tv7-fi/_definst_/smil:tv7-fi.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a4iNVXA.png"/> | TaivasTV7.fi |
 | 46  | Himlen TV7 | [>](https://vod.tv7.fi/tv7-se/_definst_/smil:tv7-se.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/a4iNVXA.png"/> | HimlenTV7.fi |


### PR DESCRIPTION
These stream urls only show you an advertisement for a web page

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/34ea7078-c803-4c58-968b-716351dc577f" />
