### PR TITLE
Add 4 new macedonian tv channels

### DIFF
--- a/lists/north_macedonia.md
+++ b/lists/north_macedonia.md
@@ -41,7 +41,8 @@
 | 11 | TV 24 Ⓖ | [>](https://hls.telekabel.com.mk:1936/live/11/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MFKeNZx.png"/> | 24.mk |
 | 12 | B1 Ⓖ | [x](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Shutel)/index.m3u8) | <img height="20" src="https://i.imgur.com/UgUpZ2M.png"/> | b1 |
 | 13 | M»Net Kids | [x](http://ares.mnet.mk/hls/mnet-kids.m3u8) | <img height="20" src="https://i.imgur.com/XZwtu7Q.png"/> | kids.mnet.mk |
-| 14 | ТВ НОВА 12 | [x](http://151.236.247.171:8080/nova/index.m3u8) | <img height="20" src="https://i.imgur.com/Qo3Hj3t.png"/> | tvnova12.mk|
+| 14 | ТВ НОВА 12 | [>](http://151.236.247.171:8080/nova/index.m3u8) | <img height="20" src="https://i.imgur.com/Qo3Hj3t.png"/> | tvnova12.mk|
+| 15 | Вардар тв | [>](https://streaming.iptv.mk/fcvardar/index.fmp4.m3u8) | <img height="20" src="https://i.imgur.com/c2JHg9R.png"/> | vardar tv|
 
 <h2>Web</h2>
 

--- a/lists/north_macedonia.md
+++ b/lists/north_macedonia.md
@@ -43,6 +43,7 @@
 | 13 | M»Net Kids | [x](http://ares.mnet.mk/hls/mnet-kids.m3u8) | <img height="20" src="https://i.imgur.com/XZwtu7Q.png"/> | kids.mnet.mk |
 | 14 | ТВ НОВА 12 | [>](http://151.236.247.171:8080/nova/index.m3u8) | <img height="20" src="https://i.imgur.com/Qo3Hj3t.png"/> | tvnova12.mk|
 | 15 | Вардар тв | [>](https://streaming.iptv.mk/fcvardar/index.fmp4.m3u8) | <img height="20" src="https://i.imgur.com/c2JHg9R.png"/> | vardar tv|
+| 15 | ЗОНА М1 ТВ | [>](https://zonam1.ddns.net/hls/stream1.m3u8) | <img height="20" src="https://i.imgur.com/yTR7A0d.png"/> | zona m1|
 
 <h2>Web</h2>
 

--- a/lists/north_macedonia.md
+++ b/lists/north_macedonia.md
@@ -41,6 +41,7 @@
 | 11 | TV 24 Ⓖ | [>](https://hls.telekabel.com.mk:1936/live/11/playlist.m3u8) | <img height="20" src="https://i.imgur.com/MFKeNZx.png"/> | 24.mk |
 | 12 | B1 Ⓖ | [x](https://vipottbpkstream.vip.hr/Content/onevip-hls/Live/Channel(Shutel)/index.m3u8) | <img height="20" src="https://i.imgur.com/UgUpZ2M.png"/> | b1 |
 | 13 | M»Net Kids | [x](http://ares.mnet.mk/hls/mnet-kids.m3u8) | <img height="20" src="https://i.imgur.com/XZwtu7Q.png"/> | kids.mnet.mk |
+| 14 | ТВ НОВА 12 | [x](http://151.236.247.171:8080/nova/index.m3u8) | <img height="20" src="https://i.imgur.com/Qo3Hj3t.png"/> | tvnova12.mk|
 
 <h2>Web</h2>
 

--- a/lists/north_macedonia.md
+++ b/lists/north_macedonia.md
@@ -62,3 +62,4 @@
 | 11 | INTV | [>](http://tv1.intv.mk:1935/live/intv/index.m3u8) | <img height="20" src="https://i.imgur.com/K7BSjqY.png"/> | |
 | 12 | Macedonian Documentary Channel | [>](https://giganet.mk/hls/macdoc.m3u8) | <img height="20" src="https://i.imgur.com/uYyG2oA.png"/> |  |
 | 13 | Вистел| [>](https://live.vtv.mk/live/vtv/chunks.m3u8) | <img height="20" src="https://i.imgur.com/MbM0E6L.png"/> | |
+| 13 | Стар Плус | [>](https://live.muzickatv.mk/live/StarMusic2.m3u8) | <img height="20" src="https://i.imgur.com/01yz22a.png"/> | |


### PR DESCRIPTION
Added 4 new Macedonian TV channels: Нова 12, Вардар, Зона М1, and Стар Плус TV.