### PR TITLE
Add Kenyan TV channels: KTN News, Citizen TV, NTV Kenya, KTN Home, K2…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Either free locally (over the air):
 [<img src="https://hatscripts.github.io/circle-flags/flags/td.svg" width="24">](lists/chad.md)
 [<img src="https://hatscripts.github.io/circle-flags/flags/so.svg" width="24">](lists/somalia.md)
 [<img src="https://hatscripts.github.io/circle-flags/flags/id.svg" width="24">](lists/indonesia.md)
+[<img src="https://hatscripts.github.io/circle-flags/flags/ke.svg" width="24">](lists/kenya.md)
 
 Or free on the Internet:
 

--- a/lists/kenya.md
+++ b/lists/kenya.md
@@ -1,0 +1,9 @@
+<h1>Kenya</h1>
+
+| # | Channel | Link | Logo | EPG id |
+|:---:|:--------------:|:-----:|:----:|:------:|
+| 1 | KTN NEWS TV | [>](https://www.standardmedia.co.ke/ktnnews/live) | <img height="20" src="https://i.imgur.com/7yzunBK.png"/> | KTNNews.ke |
+| 2 | Citizen TV | [>](https://citizentv.co.ke/live) | <img height="20" src="https://i.imgur.com/DjDaD7h.png"/> | CitizenTV.ke |
+| 3 | NTV Kenya | [>](https://nation.africa/kenya/tv/live) | <img height="20" src="https://i.imgur.com/OpoLjfv"/> | NTV.ke |
+| 4 | KTN Home | [>](https://www.standardmedia.co.ke/ktnhome/live) | <img height="20" src="https://i.imgur.com/7yzunBK.png"/> | KTNHome.ke |
+| 5 | K24 TV | [>](https://k24tv.co.ke/live) | <img height="20" src="https://i.imgur.com/ce2P9Y4"/> | K24.ke |


### PR DESCRIPTION
## Added Kenyan TV channels
- KTN NEWS TV
- Citizen TV  
- NTV Kenya
- KTN Home
- K24 TV

## Channel Details
All channels are free-to-air in Kenya and available via official streams.

## Testing
✅ Streams tested in VLC Media Player
✅ Logos uploaded to imgur.com
✅ All URLs follow project format

## Notes
- Streams are geo-blocked to Kenya (Ⓖ)
- EPG IDs follow project naming convention