### PR TITLE
Add Alabbassia TV to Iraq list

### DIFF
--- a/lists/iraq.md
+++ b/lists/iraq.md
@@ -15,3 +15,4 @@
 | 11  | Iraq Future Ⓢ       | [>](https://streaming.viewmedia.tv/viewsatstream40/viewsatstream40.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/Z7woTe5.png"/> | IraqFuture.iq |
 | 12  | Turkmeneli TV       | [>](https://137840.global.ssl.fastly.net/edge/live_6b7c6e205afb11ebb010f5a331abaf98/playlist.m3u8) | <img height="20" src="https://i.imgur.com/iUhhg4B.png"/> | TurkmeneliTV.iq |
 | 13  | Zagros TV       | [>](https://5a3ed7a72ed4b.streamlock.net/zagrostv/SMIL:myStream.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/UjIuIQX.png"/> | ZagrosTV.iq |
+| 14  | Alabbassia TV | [>](https://stream.alabbassia.com/live/alabbassia/index.m3u8) | <img height="20" src="https://i.imgur.com/BPyrjO5.png"/> | AlabbassiaTV.iq |


### PR DESCRIPTION
Add Alabbassia TV to Iraq list.

Official source:
https://github.com/Alabbassia2026/Alabbassia-TV-Official

Official HLS stream:
https://stream.alabbassia.com/live/alabbassia/index.m3u8

Logo:
https://i.imgur.com/BPyrjO5.png

Details:
- Country: Iraq
- Quality: 1080p Full HD
- Protocol: HLS
- Status: Operational
- The stream is officially provided by Alabbassia TV.
- The channel is free to watch and does not require a paid subscription.