### PR TITLE
Add TV Mulhouse and TV Alsace

### DIFF
--- a/lists/france.md
+++ b/lists/france.md
@@ -17,6 +17,8 @@
 | 21  | L'Équipe ⒹⒼ    | [>](https://www.dailymotion.com/video/x2lefik) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/L%27%C3%89quipe_wordmark.svg/640px-L%27%C3%89quipe_wordmark.svg.png"/> | LEquipe.fr |
 | 32  | France Inter Ⓨ | [>](https://www.youtube.com/c/FranceInter/live) | <img height="20" src="https://i.imgur.com/d9Ncl8m.png"/> | FranceInter.fr |
 | 34  | CGTN Français | [>](https://news.cgtn.com/resource/live/french/cgtn-f.m3u8) | <img height="20" src="https://i.imgur.com/fMsJYzl.png"/> | CGTNFrench.cn |
+| - | TV Mulhouse | [>](http://194.163.157.137:8080/hls/radiomulhouse.m3u8) | <img height="20" src="https://i.imgur.com/4esQG8H.png"/> | TVMulhouse.fr |
+| - | TV Alsace | [>](http://194.163.157.137:8080/hls/radioalsace.m3u8) | <img height="20" src="https://i.imgur.com/zaJDEOv.png"/> | TVAlsace.fr |
 
 <h2>DVB-S</h2>
 


### PR DESCRIPTION
Adds two free-to-air French regional channels:

- TV Mulhouse
- TV Alsace

Both streams are:
- publicly accessible
- hosted by the broadcaster
- available in 1080p
- already listed in iptv-org

Official websites:
http://tvmulhouse.fr/
http://tvalsace.fr/

Streams:
http://194.163.157.137:8080/hls/radiomulhouse.m3u8 http://194.163.157.137:8080/hls/radioalsace.m3u8