### PR TITLE
Security: sanitize channel attributes to prevent M3U8 attribute injection

### DIFF
--- a/make_playlist.py
+++ b/make_playlist.py
@@ -96,21 +96,21 @@ class Channel:  # pylint: disable=too-few-public-methods,too-many-instance-attri
     """A single channel entry parsed from a markdown list line."""
 
     def __init__(self, group, md_line, country_code=""):
-        self.group = group
+        self.group = group.replace('"', '')
         self.country_code = country_code
         md_line = md_line.strip()
         parts = md_line.split("|")
         self.number = parts[1].strip()
-        self.name = parts[2].strip()
+        self.name = parts[2].strip().replace('"', '')
         self.url = parts[3].strip()
         self.url = self.url[self.url.find("(")+1:self.url.rfind(")")]
         self.logo = parts[4].strip()
-        self.logo = self.logo[self.logo.find('src="')+5:self.logo.rfind('"')]
+        self.logo = self.logo[self.logo.find('src="')+5:self.logo.rfind('"')].replace('"', '')
 
         self.chno = self.number if self.number and self.number != "0" else None
 
         if len(parts) > 6:
-            self.epg = parts[5].strip()
+            self.epg = parts[5].strip().replace('"', '')
         else:
             self.epg = None
 


### PR DESCRIPTION
## Summary
- `Channel.__init__` embeds `group`, `name`, `logo` and `epg` directly into quoted `#EXTINF` attributes (`tvg-name`, `tvg-logo`, `tvg-id`, `group-title`) without escaping
- A value containing a double quote can break out of its attribute and inject arbitrary extra attributes/content into the generated playlist
- Strips embedded `"` characters from these four fields at parse time — minimal, single-file fix

This supersedes #1011, which attempted the same fix but is now stale/conflicting against `master` and also had a bug: its `logo` sanitization line was immediately overwritten by the original unsanitized line right after it, so the logo field was never actually fixed. This PR fixes that too.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('make_playlist.py').read())"` — syntax OK
- [x] Run `make_playlist.py` locally and confirm output is unchanged for existing well-formed entries