### PR TITLE
Add Aguacate TV and AS3 Sport TV to Venezuela list

### DIFF
--- a/lists/venezuela.md
+++ b/lists/venezuela.md
@@ -14,3 +14,5 @@ https://en.wikipedia.org/wiki/List_of_television_networks_in_Venezuela
 | 9   | Chivacoatv Internacional | [x](https://glb.bozztv.com/glb/ssh101/1234chivacoa/index.m3u8) | <img height="20" src="https://i.imgur.com/9rbwZFY.png"/> | Chivacoatv.ve |
 | 10  | Latina TV       | [>](https://streamtv.latinamedios.com:3413/live/latinatvlive.m3u8) | <img height="20" src="https://intervenhosting.net/imagenes/latinatv.jpg"> | LatinaTV.ve |
 | 11  | inter TV       | [>](https://streamtv.intervenhosting.net:3439/hybrid/play.m3u8) | <img height="20" src="https://intervenhosting.net/imagenes/itv.jpg"> | interTV.ve |
+| 12  | Aguacate TV     | [>](https://streamtv.intervenhosting.net:3040/hybrid/play.m3u8) | <img height="20" src="https://intervenhosting.net/imagenes/aguacatetv.jpg"> | AguacateTV.ve |
+| 13  | AS3 Sport TV    | [>](https://streamtv.as3sport.online:3394/hybrid/play.m3u8) | <img height="20" src="https://intervenhosting.net/imagenes/as3sporttv.jpg"> | AS3SportTV.ve |

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -3387,6 +3387,10 @@ https://raw.githubusercontent.com/BellezaEmporium/IPTV_Exception/master/channels
 https://streamtv.latinamedios.com:3413/live/latinatvlive.m3u8
 #EXTINF:-1 tvg-name="inter TV" tvg-logo="https://intervenhosting.net/imagenes/itv.jpg" tvg-id="interTV.ve" tvg-chno="11" tvg-country="VE" group-title="Venezuela",inter TV
 https://streamtv.intervenhosting.net:3439/hybrid/play.m3u8
+#EXTINF:-1 tvg-name="Aguacate TV" tvg-logo="https://intervenhosting.net/imagenes/aguacatetv.jpg" tvg-id="AguacateTV.ve" tvg-chno="12" tvg-country="VE" group-title="Venezuela",Aguacate TV
+https://streamtv.intervenhosting.net:3040/hybrid/play.m3u8
+#EXTINF:-1 tvg-name="AS3 Sport TV" tvg-logo="https://intervenhosting.net/imagenes/as3sporttv.jpg" tvg-id="AS3SportTV.ve" tvg-chno="13" tvg-country="VE" group-title="Venezuela",AS3 Sport TV
+https://streamtv.as3sport.online:3394/hybrid/play.m3u8
 #EXTINF:-1 tvg-name="Al Jazeera Documentary Ⓖ" tvg-logo="https://upload.wikimedia.org/wikipedia/en/e/e6/Al_Jazeera_Doc.png" tvg-id="AlJazeeraDocumentary.qa" group-title="Documentaries (AR)",Al Jazeera Documentary Ⓖ
 https://live-hls-web-ajd.getaj.net/AJD/index.m3u8
 #EXTINF:-1 tvg-name="CGTN Documentary English Ⓢ" tvg-logo="https://i.imgur.com/JHv0WxM.png" tvg-id="CGTNDocumentary.cn" group-title="Documentaries (EN)",CGTN Documentary English Ⓢ

--- a/playlists/playlist_venezuela.m3u8
+++ b/playlists/playlist_venezuela.m3u8
@@ -15,3 +15,7 @@ https://raw.githubusercontent.com/BellezaEmporium/IPTV_Exception/master/channels
 https://streamtv.latinamedios.com:3413/live/latinatvlive.m3u8
 #EXTINF:-1 tvg-name="inter TV" tvg-logo="https://intervenhosting.net/imagenes/itv.jpg" tvg-id="interTV.ve" tvg-chno="11" tvg-country="VE" group-title="Venezuela",inter TV
 https://streamtv.intervenhosting.net:3439/hybrid/play.m3u8
+#EXTINF:-1 tvg-name="Aguacate TV" tvg-logo="https://intervenhosting.net/imagenes/aguacatetv.jpg" tvg-id="AguacateTV.ve" tvg-chno="12" tvg-country="VE" group-title="Venezuela",Aguacate TV
+https://streamtv.intervenhosting.net:3040/hybrid/play.m3u8
+#EXTINF:-1 tvg-name="AS3 Sport TV" tvg-logo="https://intervenhosting.net/imagenes/as3sporttv.jpg" tvg-id="AS3SportTV.ve" tvg-chno="13" tvg-country="VE" group-title="Venezuela",AS3 Sport TV
+https://streamtv.as3sport.online:3394/hybrid/play.m3u8


### PR DESCRIPTION
## Summary
- Adds Aguacate TV and AS3 Sport TV to `lists/venezuela.md`, regenerated via `make_playlist.py`
- Latina TV was already present; inter TV was already added in a prior merge — both skipped
- Assigned `tvg-chno` 12/13 to avoid colliding with the existing `tvg-chno="1"` (Venevisión)
- Normalized `AS3 Sport TV`'s EPG id to `AS3SportTV.ve` (no embedded space) for consistency with the rest of the file

Related to #1065, which proposed the same two channels but also (accidentally, per its own description) stripped the `x-tvg-url` EPG header from `playlists/playlist_venezuela.m3u8` and hand-edited the generated file directly instead of going through `lists/venezuela.md`.

## Test plan
- [ ] `python3 make_playlist.py` regenerates cleanly with no other diffs