### PR TITLE
Move unreachable China streams (CCTV-5, CCTV-5+, CETV-1..4) to invalid

### DIFF
--- a/lists/china.md
+++ b/lists/china.md
@@ -12,28 +12,22 @@ https://en.wikipedia.org/wiki/List_of_Chinese-language_television_channels
 | 4   | CCTV-4 中文国际（亚） | [>](http://74.91.26.218:82/live/cctv4hd.m3u8) | <img height="20" src="https://i.imgur.com/ovUSVEQ.png"/> | CCTV4Asia.cn |
 | 5   | CCTV-4 中文国际（欧）| [>](https://dash2.antik.sk/live/test_cctv_tizen/playlist.m3u8) | <img height="20" src="https://i.imgur.com/kx8metk.png"/> | CCTV4Europe.cn |
 | 6   | CCTV-4 中文国际（美） Ⓢ | [>](https://global.cgtn.cicc.media.caton.cloud/master/cgtn-america.m3u8) | <img height="20" src="https://i.imgur.com/1TPiRqR.png"/> | CCTV4America.cn |
-| 7   | CCTV-5 体育 | [>](https://node1.olelive.com:6443/live/CCTV5HD/hls.m3u8) | <img height="20" src="https://i.imgur.com/Mut2omN.png"/> | CCTV5.cn |
-| 8   | CCTV-5+ 体育赛事 | [>](https://node1.olelive.com:6443/live/CCTV5PHD/hls.m3u8) | <img height="20" src="https://i.imgur.com/UNjmQVS.png"/> | CCTV5Plus.cn |
-| 9   | CCTV-6 电影 | [>](http://69.30.245.50/live/cctv6.m3u8) | <img height="20" src="https://i.imgur.com/SsPN5I3.png"/> | CCTV6.cn |
-| 10  | CCTV-7 国防军事 | [>](http://74.91.26.218:82/live/cctv7hd.m3u8) | <img height="20" src="https://i.imgur.com/GhXlUpM.png"/> | CCTV7.cn |
-| 11  | CCTV-8 电视剧 | [>](http://74.91.26.218:82/live/cctv8hd.m3u8) | <img height="20" src="https://i.imgur.com/Qg1opg9.png"/> | CCTV8.cn |
-| 12  | CCTV-9 纪录 | [>](http://74.91.26.218:82/live/cctv9hd.m3u8) | <img height="20" src="https://i.imgur.com/Ruyzhu5.png"/> | CCTV9.cn |
-| 13  | CCTV-10 科教 | [>](http://74.91.26.218:82/live/cctv10hd.m3u8) | <img height="20" src="https://i.imgur.com/W8JNs1s.png"/> | CCTV10.cn |
-| 14  | CCTV-11 戏曲 | [>](http://74.91.26.218:82/live/cctv11hd.m3u8) | <img height="20" src="https://i.imgur.com/0MeegZK.png"/> | CCTV11.cn |
-| 15  | CCTV-12 社会与法 | [>](http://74.91.26.218:82/live/cctv12hd.m3u8) | <img height="20" src="https://i.imgur.com/gZNwF1a.png"/> | CCTV12.cn |
-| 16  | CCTV-13 新闻 | [>](http://74.91.26.218:82/live/cctv13hd.m3u8) | <img height="20" src="https://i.imgur.com/pPO8uJN.png"/> | CCTV13.cn |
-| 17  | CCTV-14 少儿 | [>](http://74.91.26.218:82/live/cctv14hd.m3u8) | <img height="20" src="https://i.imgur.com/SORrhtE.png"/> | CCTV14.cn |
-| 18  | CCTV-15 音乐 | [x]() | <img height="20" src="https://i.imgur.com/V9I1ZyB.png"/> | CCTV15.cn |
-| 19  | CCTV-16 奥林匹克 | [>](http://74.91.26.218:82/live/cctv16hd.m3u8) | <img height="20" src="https://i.imgur.com/gaA4Cjy.png"/> | CCTV16.cn |
-| 20  | CCTV-17 农业农村 | [>](http://74.91.26.218:82/live/cctv17hd.m3u8) | <img height="20" src="https://i.imgur.com/XMsoHut.png"/> | CCTV17.cn |
-| 21  | CETV-1 | [>](http://txycsbl.centv.cn/zb/0628cetv1.m3u8) | <img height="20" src="https://i.imgur.com/AMcIAOV.png"/> | CETV1.cn |
-| 22  | CETV-2 | [>](http://txycsbl.centv.cn/zb/0822cetv2.m3u8) | <img height="20" src="https://i.imgur.com/a9mvoeP.png"/> | CETV2.cn |
-| 23  | CETV-3 | [>](http://txycsbl.centv.cn/zb/0822cetv3.m3u8) | <img height="20" src="https://i.imgur.com/t8o5ZKt.png"/> | CETV3.cn |
-| 24  | CETV-4 | [>](http://txycsbl.centv.cn/zb/0822cetv4.m3u8) | <img height="20" src="https://i.imgur.com/BRe0ybV.png"/> | CETV4.cn |
-| 25  | FZTV-1 News 新闻综合频道 | [>](http://live.zohi.tv/video/s10001-fztv-1/index.m3u8) | <img height="20" src="https://i.imgur.com/QvBxGw3.png"/> | FZTV1.cn |
-| 26  | FZTV-2 Movie & Drama Channel 影视频道 | [x](http://live.zohi.tv/video/s10001-fztv-2/index.m3u8) | <img height="20" src="https://i.imgur.com/xRP80XS.png"/> | FZTV2.cn |
-| 27  | FZTV-3 Lifestyle Channel 生活频道 | [>](http://live.zohi.tv/video/s10001-fztv-3/index.m3u8) | <img height="20" src="https://i.imgur.com/jt7CWDT.png"/> | FZTV3.cn |
-| 28  | FZTV-4 Children 少儿频道  | [>](http://live.zohi.tv/video/s10001-fztv-4/index.m3u8) | <img height="20" src="https://i.imgur.com/J4WtNTX.png"/> | FZTVkids.cn |
+| 7   | CCTV-6 电影 | [>](http://69.30.245.50/live/cctv6.m3u8) | <img height="20" src="https://i.imgur.com/SsPN5I3.png"/> | CCTV6.cn |
+| 8   | CCTV-7 国防军事 | [>](http://74.91.26.218:82/live/cctv7hd.m3u8) | <img height="20" src="https://i.imgur.com/GhXlUpM.png"/> | CCTV7.cn |
+| 9   | CCTV-8 电视剧 | [>](http://74.91.26.218:82/live/cctv8hd.m3u8) | <img height="20" src="https://i.imgur.com/Qg1opg9.png"/> | CCTV8.cn |
+| 10  | CCTV-9 纪录 | [>](http://74.91.26.218:82/live/cctv9hd.m3u8) | <img height="20" src="https://i.imgur.com/Ruyzhu5.png"/> | CCTV9.cn |
+| 11  | CCTV-10 科教 | [>](http://74.91.26.218:82/live/cctv10hd.m3u8) | <img height="20" src="https://i.imgur.com/W8JNs1s.png"/> | CCTV10.cn |
+| 12  | CCTV-11 戏曲 | [>](http://74.91.26.218:82/live/cctv11hd.m3u8) | <img height="20" src="https://i.imgur.com/0MeegZK.png"/> | CCTV11.cn |
+| 13  | CCTV-12 社会与法 | [>](http://74.91.26.218:82/live/cctv12hd.m3u8) | <img height="20" src="https://i.imgur.com/gZNwF1a.png"/> | CCTV12.cn |
+| 14  | CCTV-13 新闻 | [>](http://74.91.26.218:82/live/cctv13hd.m3u8) | <img height="20" src="https://i.imgur.com/pPO8uJN.png"/> | CCTV13.cn |
+| 15  | CCTV-14 少儿 | [>](http://74.91.26.218:82/live/cctv14hd.m3u8) | <img height="20" src="https://i.imgur.com/SORrhtE.png"/> | CCTV14.cn |
+| 16  | CCTV-15 音乐 | [x]() | <img height="20" src="https://i.imgur.com/V9I1ZyB.png"/> | CCTV15.cn |
+| 17  | CCTV-16 奥林匹克 | [>](http://74.91.26.218:82/live/cctv16hd.m3u8) | <img height="20" src="https://i.imgur.com/gaA4Cjy.png"/> | CCTV16.cn |
+| 18  | CCTV-17 农业农村 | [>](http://74.91.26.218:82/live/cctv17hd.m3u8) | <img height="20" src="https://i.imgur.com/XMsoHut.png"/> | CCTV17.cn |
+| 19  | FZTV-1 News 新闻综合频道 | [>](http://live.zohi.tv/video/s10001-fztv-1/index.m3u8) | <img height="20" src="https://i.imgur.com/QvBxGw3.png"/> | FZTV1.cn |
+| 20  | FZTV-2 Movie & Drama Channel 影视频道 | [x](http://live.zohi.tv/video/s10001-fztv-2/index.m3u8) | <img height="20" src="https://i.imgur.com/xRP80XS.png"/> | FZTV2.cn |
+| 21  | FZTV-3 Lifestyle Channel 生活频道 | [>](http://live.zohi.tv/video/s10001-fztv-3/index.m3u8) | <img height="20" src="https://i.imgur.com/jt7CWDT.png"/> | FZTV3.cn |
+| 22  | FZTV-4 Children 少儿频道  | [>](http://live.zohi.tv/video/s10001-fztv-4/index.m3u8) | <img height="20" src="https://i.imgur.com/J4WtNTX.png"/> | FZTVkids.cn |
 
 <h2>Provincial and prefectural networks</h2>
 
@@ -45,3 +39,14 @@ https://en.wikipedia.org/wiki/List_of_Chinese-language_television_channels
 | #   | Channel          | Link  | Logo | EPG id |
 |:---:|:----------------:|:-----:|:----:|:------:|
 | 1   | TV BRICS Chinese | [>](https://chibrics.mediacdn.ru/cdn/brics/chinese/playlist.m3u8) | <img height="20" src="https://i.imgur.com/896132Z.png"/> | TVBRICSChinese.cn |
+
+<h2>Invalid</h2>
+
+| #   | Channel        | Link  | Logo | EPG id |
+|:---:|:--------------:|:-----:|:----:|:------:|
+| 1   | CCTV-5 体育 | [x](https://node1.olelive.com:6443/live/CCTV5HD/hls.m3u8) | <img height="20" src="https://i.imgur.com/Mut2omN.png"/> | CCTV5.cn |
+| 2   | CCTV-5+ 体育赛事 | [x](https://node1.olelive.com:6443/live/CCTV5PHD/hls.m3u8) | <img height="20" src="https://i.imgur.com/UNjmQVS.png"/> | CCTV5Plus.cn |
+| 3   | CETV-1 | [x](http://txycsbl.centv.cn/zb/0628cetv1.m3u8) | <img height="20" src="https://i.imgur.com/AMcIAOV.png"/> | CETV1.cn |
+| 4   | CETV-2 | [x](http://txycsbl.centv.cn/zb/0822cetv2.m3u8) | <img height="20" src="https://i.imgur.com/a9mvoeP.png"/> | CETV2.cn |
+| 5   | CETV-3 | [x](http://txycsbl.centv.cn/zb/0822cetv3.m3u8) | <img height="20" src="https://i.imgur.com/t8o5ZKt.png"/> | CETV3.cn |
+| 6   | CETV-4 | [x](http://txycsbl.centv.cn/zb/0822cetv4.m3u8) | <img height="20" src="https://i.imgur.com/BRe0ybV.png"/> | CETV4.cn |


### PR DESCRIPTION
Tested all stream URLs in lists/china.md with curl (HTTP status + #EXTM3U header check).

The following channels are unreachable and have been moved to a new Invalid section with [x]:

- CCTV-5 / CCTV-5+ (node1.olelive.com:6443 - connection failure)
- CETV-1 to CETV-4 (txycsbl.centv.cn - host unreachable)

All other channels return HTTP 200 with a valid #EXTM3U playlist.
Note: CCTV-16 returns a geo-block notice (content is not available in your area) from some regions, but it was left unchanged since it may work elsewhere.

Only .md files were modified.