### PR TITLE
Remove Star Central Greece - not a valid stream

### DIFF
--- a/lists/greece.md
+++ b/lists/greece.md
@@ -86,7 +86,6 @@
 | #  | Channel             | Link                                                                                       |                           Logo                            |     EPG id     |
 |:--:|:--------------------|--------------------------------------------------------------------------------------------|:---------------------------------------------------------:|:--------------:|
 | 71 | Epsilon             | [>](https://neon.streams.gr:8081/epsilontv/index.m3u8)                                     | <img height="20" src="https://i.imgur.com/vUQSDvZ.png"/>  |   epsilon.gr   |
-| 72 | Star Central Greece | [>](https://telmaco-cdn.akamaized.net/starcgr/default/dash/LAMIAStar-video=3000000.dash)   | <img height="20" src="https://i.imgur.com/BTUEvxg.png"/>  | digitalstar.gr |
 | 73 | 91NRG               | [>](http://tv.nrg91.gr:1935/onweb/live/master.m3u8)                                        |  <img height="20" src="https://i.imgur.com/g1pCRRG.png">  |    nrg91.gr    |
 
 

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -975,8 +975,6 @@ https://thor.mental-media.gr:19360/imp/imp.m3u8
 https://rtmp.win:3793/live/mesogeiostvlive.m3u8
 #EXTINF:-1 tvg-name="Epsilon" tvg-logo="https://i.imgur.com/vUQSDvZ.png" tvg-id="epsilon.gr" tvg-chno="71" tvg-country="GR" group-title="Greece",Epsilon
 https://neon.streams.gr:8081/epsilontv/index.m3u8
-#EXTINF:-1 tvg-name="Star Central Greece" tvg-logo="https://i.imgur.com/BTUEvxg.png" tvg-id="digitalstar.gr" tvg-chno="72" tvg-country="GR" group-title="Greece",Star Central Greece
-https://telmaco-cdn.akamaized.net/starcgr/default/dash/LAMIAStar-video=3000000.dash
 #EXTINF:-1 tvg-name="91NRG" tvg-logo="https://i.imgur.com/g1pCRRG.png" tvg-id="nrg91.gr" tvg-chno="73" tvg-country="GR" group-title="Greece",91NRG
 http://tv.nrg91.gr:1935/onweb/live/master.m3u8
 #EXTINF:-1 tvg-name="Astra" tvg-logo="https://i.imgur.com/oYRPfZm.png" tvg-id="astratv.gr" tvg-chno="81" tvg-country="GR" group-title="Greece",Astra

--- a/playlists/playlist_greece.m3u8
+++ b/playlists/playlist_greece.m3u8
@@ -89,8 +89,6 @@ https://thor.mental-media.gr:19360/imp/imp.m3u8
 https://rtmp.win:3793/live/mesogeiostvlive.m3u8
 #EXTINF:-1 tvg-name="Epsilon" tvg-logo="https://i.imgur.com/vUQSDvZ.png" tvg-id="epsilon.gr" tvg-chno="71" tvg-country="GR" group-title="Greece",Epsilon
 https://neon.streams.gr:8081/epsilontv/index.m3u8
-#EXTINF:-1 tvg-name="Star Central Greece" tvg-logo="https://i.imgur.com/BTUEvxg.png" tvg-id="digitalstar.gr" tvg-chno="72" tvg-country="GR" group-title="Greece",Star Central Greece
-https://telmaco-cdn.akamaized.net/starcgr/default/dash/LAMIAStar-video=3000000.dash
 #EXTINF:-1 tvg-name="91NRG" tvg-logo="https://i.imgur.com/g1pCRRG.png" tvg-id="nrg91.gr" tvg-chno="73" tvg-country="GR" group-title="Greece",91NRG
 http://tv.nrg91.gr:1935/onweb/live/master.m3u8
 #EXTINF:-1 tvg-name="Astra" tvg-logo="https://i.imgur.com/oYRPfZm.png" tvg-id="astratv.gr" tvg-chno="81" tvg-country="GR" group-title="Greece",Astra


### PR DESCRIPTION
Corrects a mistake introduced in #1151: the URL answers HTTP 200 with binary data, but that data is a raw MP4 fragment (ftyp/moov boxes), not an HLS/DASH playlist a player can open. No working replacement found, so removing rather than leaving a link that looks fixed but isn't.