### PR TITLE
Add 3 newly-found BS cids without moving existing ones

### DIFF
--- a/lists/japan.md
+++ b/lists/japan.md
@@ -17,15 +17,15 @@
 | # |       Channel        |                                                       Link                                                       |                           Logo                           |    EPG id     |
 |:-:|:--------------------:|:----------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------:|:-------------:|
 | BS101 |        NHK BS        |                   [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs02#.m3u8)                   | <img height="30" src="https://i.imgur.com/t0uZcSR.png"/> |   NHKBS.jp    |
-| BS4K101 |      NHK BSP4K       |                   [>]([NO PUBLIC STREAM])                   | <img height="30" src="https://i.imgur.com/uvPpFo5.png"/> |  NHKBSP4K.jp  |
+| BS4K101 |      NHK BSP4K       |                   [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs01#.m3u8)                   | <img height="30" src="https://i.imgur.com/uvPpFo5.png"/> |  NHKBSP4K.jp  |
 | BS141 |       BS日テレ        |                   [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs03#.m3u8)                   | <img height="30" src="https://i.imgur.com/26ATUNc.png"/> | BSNipponTV.jp |
 | BS151 |       BS朝日       | [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs04#.m3u8) | <img height="30" src="https://i.imgur.com/Cl68ZMA.png"/> |  BSAsahi.jp   |
 | BS161 |        BS-TBS        |                   [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs05#.m3u8)                   | <img height="30" src="https://i.imgur.com/BSt9UG2.png"/> |   BSTBS.jp    |
 | BS171 |     BSテレ東      | [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs06#.m3u8) | <img height="30" src="https://i.imgur.com/LsQlNcz.png"/> | BSTVTokyo.jp  |
 | BS181 |     BSフジ        |                   [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs11#.m3u8)                   | <img height="30" src="https://i.imgur.com/N4xeDxJ.png"/> |   BSFuji.jp   |
-| BS191 |  WOWOWプライム     |    [>]([NO PUBLIC STREAM]) | <img height="30" src="https://www.lyngsat.com/logo/tv/ww/wowow_prime.png"/> | WOWOWPrime.jp |
+| BS191 |  WOWOWプライム     |    [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs12#.m3u8) | <img height="30" src="https://www.lyngsat.com/logo/tv/ww/wowow_prime.png"/> | WOWOWPrime.jp |
 | BS192 |  WOWOWライブ         |     [>]([NO PUBLIC STREAM]) |  <img height="30" src="https://www.lyngsat.com/logo/tv/ww/wowow_live.png"/> | WOWOWLive.jp |
-| BS193 |  WOWOWシネマ　     |     [>]([NO PUBLIC STREAM]) |  <img height="30" src="https://www.lyngsat.com/logo/tv/ww/wowow_cinema.png"/> | WOWOWCinema.jp |
+| BS193 |  WOWOWシネマ　     |     [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs08#.m3u8) |  <img height="30" src="https://www.lyngsat.com/logo/tv/ww/wowow_cinema.png"/> | WOWOWCinema.jp |
 | BS200 |     BS10        |      [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs10#.m3u8) |  <img height="30" src="https://i.imgur.com/KPZiuHl.png"/> | jcom_120_110_4 |
 | BS201 | BS10スターチャンネル  |      [>](https://naori-test.netgenx.site/pxx.php?shk_cid=bs07#.m3u8) |  <img height="30" src="https://i.imgur.com/SN0ED0U.png"/> | jcom_120_200_4 |
 | BS236 |  アニマックス  |      [>]([NO PUBLIC STREAM]) |  <img height="30" src="https://i.imgur.com/jO0qUvj.png"/> | AnimaxAsia.sg@Japan |

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -2146,7 +2146,7 @@ https://naori-test.netgenx.site/pxx.php?shk_cid=hdgd05#.m3u8
 #EXTINF:-1 tvg-name="NHK BS" tvg-logo="https://i.imgur.com/t0uZcSR.png" tvg-id="NHKBS.jp" tvg-chno="BS101" tvg-country="JP" group-title="日本 / Japan",NHK BS
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs02#.m3u8
 #EXTINF:-1 tvg-name="NHK BSP4K" tvg-logo="https://i.imgur.com/uvPpFo5.png" tvg-id="NHKBSP4K.jp" tvg-chno="BS4K101" tvg-country="JP" group-title="日本 / Japan",NHK BSP4K
-[NO PUBLIC STREAM]
+https://naori-test.netgenx.site/pxx.php?shk_cid=bs01#.m3u8
 #EXTINF:-1 tvg-name="BS日テレ" tvg-logo="https://i.imgur.com/26ATUNc.png" tvg-id="BSNipponTV.jp" tvg-chno="BS141" tvg-country="JP" group-title="日本 / Japan",BS日テレ
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs03#.m3u8
 #EXTINF:-1 tvg-name="BS朝日" tvg-logo="https://i.imgur.com/Cl68ZMA.png" tvg-id="BSAsahi.jp" tvg-chno="BS151" tvg-country="JP" group-title="日本 / Japan",BS朝日
@@ -2158,11 +2158,11 @@ https://naori-test.netgenx.site/pxx.php?shk_cid=bs06#.m3u8
 #EXTINF:-1 tvg-name="BSフジ" tvg-logo="https://i.imgur.com/N4xeDxJ.png" tvg-id="BSFuji.jp" tvg-chno="BS181" tvg-country="JP" group-title="日本 / Japan",BSフジ
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs11#.m3u8
 #EXTINF:-1 tvg-name="WOWOWプライム" tvg-logo="https://www.lyngsat.com/logo/tv/ww/wowow_prime.png" tvg-id="WOWOWPrime.jp" tvg-chno="BS191" tvg-country="JP" group-title="日本 / Japan",WOWOWプライム
-[NO PUBLIC STREAM]
+https://naori-test.netgenx.site/pxx.php?shk_cid=bs12#.m3u8
 #EXTINF:-1 tvg-name="WOWOWライブ" tvg-logo="https://www.lyngsat.com/logo/tv/ww/wowow_live.png" tvg-id="WOWOWLive.jp" tvg-chno="BS192" tvg-country="JP" group-title="日本 / Japan",WOWOWライブ
 [NO PUBLIC STREAM]
 #EXTINF:-1 tvg-name="WOWOWシネマ" tvg-logo="https://www.lyngsat.com/logo/tv/ww/wowow_cinema.png" tvg-id="WOWOWCinema.jp" tvg-chno="BS193" tvg-country="JP" group-title="日本 / Japan",WOWOWシネマ
-[NO PUBLIC STREAM]
+https://naori-test.netgenx.site/pxx.php?shk_cid=bs08#.m3u8
 #EXTINF:-1 tvg-name="BS10" tvg-logo="https://i.imgur.com/KPZiuHl.png" tvg-id="jcom_120_110_4" tvg-chno="BS200" tvg-country="JP" group-title="日本 / Japan",BS10
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs10#.m3u8
 #EXTINF:-1 tvg-name="BS10スターチャンネル" tvg-logo="https://i.imgur.com/SN0ED0U.png" tvg-id="jcom_120_200_4" tvg-chno="BS201" tvg-country="JP" group-title="日本 / Japan",BS10スターチャンネル

--- a/playlists/playlist_japan.m3u8
+++ b/playlists/playlist_japan.m3u8
@@ -16,7 +16,7 @@ https://naori-test.netgenx.site/pxx.php?shk_cid=hdgd05#.m3u8
 #EXTINF:-1 tvg-name="NHK BS" tvg-logo="https://i.imgur.com/t0uZcSR.png" tvg-id="NHKBS.jp" tvg-chno="BS101" tvg-country="JP" group-title="日本 / Japan",NHK BS
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs02#.m3u8
 #EXTINF:-1 tvg-name="NHK BSP4K" tvg-logo="https://i.imgur.com/uvPpFo5.png" tvg-id="NHKBSP4K.jp" tvg-chno="BS4K101" tvg-country="JP" group-title="日本 / Japan",NHK BSP4K
-[NO PUBLIC STREAM]
+https://naori-test.netgenx.site/pxx.php?shk_cid=bs01#.m3u8
 #EXTINF:-1 tvg-name="BS日テレ" tvg-logo="https://i.imgur.com/26ATUNc.png" tvg-id="BSNipponTV.jp" tvg-chno="BS141" tvg-country="JP" group-title="日本 / Japan",BS日テレ
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs03#.m3u8
 #EXTINF:-1 tvg-name="BS朝日" tvg-logo="https://i.imgur.com/Cl68ZMA.png" tvg-id="BSAsahi.jp" tvg-chno="BS151" tvg-country="JP" group-title="日本 / Japan",BS朝日
@@ -28,11 +28,11 @@ https://naori-test.netgenx.site/pxx.php?shk_cid=bs06#.m3u8
 #EXTINF:-1 tvg-name="BSフジ" tvg-logo="https://i.imgur.com/N4xeDxJ.png" tvg-id="BSFuji.jp" tvg-chno="BS181" tvg-country="JP" group-title="日本 / Japan",BSフジ
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs11#.m3u8
 #EXTINF:-1 tvg-name="WOWOWプライム" tvg-logo="https://www.lyngsat.com/logo/tv/ww/wowow_prime.png" tvg-id="WOWOWPrime.jp" tvg-chno="BS191" tvg-country="JP" group-title="日本 / Japan",WOWOWプライム
-[NO PUBLIC STREAM]
+https://naori-test.netgenx.site/pxx.php?shk_cid=bs12#.m3u8
 #EXTINF:-1 tvg-name="WOWOWライブ" tvg-logo="https://www.lyngsat.com/logo/tv/ww/wowow_live.png" tvg-id="WOWOWLive.jp" tvg-chno="BS192" tvg-country="JP" group-title="日本 / Japan",WOWOWライブ
 [NO PUBLIC STREAM]
 #EXTINF:-1 tvg-name="WOWOWシネマ" tvg-logo="https://www.lyngsat.com/logo/tv/ww/wowow_cinema.png" tvg-id="WOWOWCinema.jp" tvg-chno="BS193" tvg-country="JP" group-title="日本 / Japan",WOWOWシネマ
-[NO PUBLIC STREAM]
+https://naori-test.netgenx.site/pxx.php?shk_cid=bs08#.m3u8
 #EXTINF:-1 tvg-name="BS10" tvg-logo="https://i.imgur.com/KPZiuHl.png" tvg-id="jcom_120_110_4" tvg-chno="BS200" tvg-country="JP" group-title="日本 / Japan",BS10
 https://naori-test.netgenx.site/pxx.php?shk_cid=bs10#.m3u8
 #EXTINF:-1 tvg-name="BS10スターチャンネル" tvg-logo="https://i.imgur.com/SN0ED0U.png" tvg-id="jcom_120_200_4" tvg-chno="BS201" tvg-country="JP" group-title="日本 / Japan",BS10スターチャンネル


### PR DESCRIPTION
Alternative to #1156.

That PR found working cids (`01`, `08`, `12` - previously only `02-07,10,11` were known) for channels marked `[NO PUBLIC STREAM]`, which is valuable. But it also reassigned the cid of every already-working channel (NHK BS, BS日テレ, BS朝日, BS-TBS, BSテレ東, BSフジ) to its neighbor's old value - a clean cyclic shift across exactly six channels. That's the signature of a list/list zip misaligned by one element (e.g. inserting a new entry at the front shifted everything after it), not of channel-by-channel verification. Neither mapping carries content-level proof either way (the streams have no identifying metadata), so there's no way to tell which is right - only that the shift itself isn't evidence of correctness.

This takes only the unambiguous part: three cids nobody had before, given to the three channels that had nothing.

- NHK BSP4K -> `bs01`
- WOWOWプライム -> `bs12`
- WOWOWシネマ -> `bs08` (not `bs07` like #1156 - that's already BS10スターチャンネル's cid, and this PR doesn't move existing assignments)

Verified each resists a single flaky read (checked 4x each): `bs01`/`bs12` came back flaky (3/4 ok, real content), `bs08` came back alive (4/4). That's consistent with how `naori-test.netgenx.site` behaves in general, not a sign these are wrong.