### PR TITLE
Add ES TV (Esztergom) and Komáromi Televízió

### DIFF
--- a/lists/hungary.md
+++ b/lists/hungary.md
@@ -94,6 +94,8 @@ https://en.wikipedia.org/wiki/List_of_television_stations_in_Hungary
 | 27  | Pannon RTV    | [>](https://stream2.nmih.hu:4102/live.m3u8) | <img height="20" src="https://i.imgur.com/iD5tCjX.png" /> |
 | 28  | Tisza TV      | [x](https://live.tiszatv.hu:443/tmp_hls/stream/index.m3u8) | <img height="20" src="https://www.tiszatv.hu/style/tiszatv_logo.png" /> |
 | 29  | Hegyvidék TV (Buda TV) | [>](http://budatv.streaming.aiproduction.hu/playlist.m3u) | <img height="20" src="https://hegyvidektv.hu/wp-content/uploads/2025/05/BUDATV_logo_picon.png" /> |
+| 30  | ES TV (Esztergom) | [>](https://cloudfront44.lexanetwork.com:1344/relay44_1/HDE040.sdp/playlist.m3u8) | | EsztergomTV.hu |
+| 31  | Komáromi Televízió | [>](https://cloudfront44.lexanetwork.com:1344/relay01/HDE017.sdp/playlist.m3u8) | | KomaromiTelevizio.hu |
 
 
 <h2>Invalid</h2>

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -1117,6 +1117,10 @@ http://193.225.32.62:8890/live.m3u8
 https://stream2.nmih.hu:4102/live.m3u8
 #EXTINF:-1 tvg-name="Hegyvidék TV (Buda TV)" tvg-logo="https://hegyvidektv.hu/wp-content/uploads/2025/05/BUDATV_logo_picon.png" tvg-chno="29" tvg-country="HU" group-title="Hungary",Hegyvidék TV (Buda TV)
 http://budatv.streaming.aiproduction.hu/playlist.m3u
+#EXTINF:-1 tvg-name="ES TV (Esztergom)" tvg-logo="" tvg-id="EsztergomTV.hu" tvg-chno="30" tvg-country="HU" group-title="Hungary",ES TV (Esztergom)
+https://cloudfront44.lexanetwork.com:1344/relay44_1/HDE040.sdp/playlist.m3u8
+#EXTINF:-1 tvg-name="Komáromi Televízió" tvg-logo="" tvg-id="KomaromiTelevizio.hu" tvg-chno="31" tvg-country="HU" group-title="Hungary",Komáromi Televízió
+https://cloudfront44.lexanetwork.com:1344/relay01/HDE017.sdp/playlist.m3u8
 #EXTINF:-1 tvg-name="Duna World / M4+ Sport" tvg-logo="https://i.imgur.com/DciAdFF.png" tvg-id="DunaWorld.hu" tvg-chno="2" tvg-country="HU" group-title="Hungary",Duna World / M4+ Sport
 http://88.212.15.19/live/duna_world_hun/index.m3u8
 #EXTINF:-1 tvg-name="Putnok Városi TV" tvg-logo="https://i.imgur.com/eKXPBFb.png" tvg-id="PVTV.hu" tvg-chno="6" tvg-country="HU" group-title="Hungary",Putnok Városi TV

--- a/playlists/playlist_hungary.m3u8
+++ b/playlists/playlist_hungary.m3u8
@@ -91,6 +91,10 @@ http://193.225.32.62:8890/live.m3u8
 https://stream2.nmih.hu:4102/live.m3u8
 #EXTINF:-1 tvg-name="Hegyvidék TV (Buda TV)" tvg-logo="https://hegyvidektv.hu/wp-content/uploads/2025/05/BUDATV_logo_picon.png" tvg-chno="29" tvg-country="HU" group-title="Hungary",Hegyvidék TV (Buda TV)
 http://budatv.streaming.aiproduction.hu/playlist.m3u
+#EXTINF:-1 tvg-name="ES TV (Esztergom)" tvg-logo="" tvg-id="EsztergomTV.hu" tvg-chno="30" tvg-country="HU" group-title="Hungary",ES TV (Esztergom)
+https://cloudfront44.lexanetwork.com:1344/relay44_1/HDE040.sdp/playlist.m3u8
+#EXTINF:-1 tvg-name="Komáromi Televízió" tvg-logo="" tvg-id="KomaromiTelevizio.hu" tvg-chno="31" tvg-country="HU" group-title="Hungary",Komáromi Televízió
+https://cloudfront44.lexanetwork.com:1344/relay01/HDE017.sdp/playlist.m3u8
 #EXTINF:-1 tvg-name="Duna World / M4+ Sport" tvg-logo="https://i.imgur.com/DciAdFF.png" tvg-id="DunaWorld.hu" tvg-chno="2" tvg-country="HU" group-title="Hungary",Duna World / M4+ Sport
 http://88.212.15.19/live/duna_world_hun/index.m3u8
 #EXTINF:-1 tvg-name="Putnok Városi TV" tvg-logo="https://i.imgur.com/eKXPBFb.png" tvg-id="PVTV.hu" tvg-chno="6" tvg-country="HU" group-title="Hungary",Putnok Városi TV


### PR DESCRIPTION
Both use the same `lexanetwork.com` infrastructure as FehérvárTV (#1163) and Kapos TV (#1164). Found via each station's own official live page (estv.hu homepage, komaromtv.hu/online-adas/), which embeds a player resolving to a working relay URL. Verified 4x each, consistently alive.

Also searched ~45 other Hungarian local TV stations for lexanetwork.com usage - none of the others use it (mostly WordPress/YouTube embeds, or the station's own site is dead), so no further additions from this pass.