### PR TITLE
Fix 7 dead Irish radio stream URLs

### DIFF
--- a/lists/ireland.md
+++ b/lists/ireland.md
@@ -14,15 +14,15 @@
 
 | #   | Channel        | Link  | Logo | EPG id |
 |:---:|:--------------:|:-----:|:----:|:------:|
-| 1 | Today FM | [>](https://stream.audioxi.com/TDAAC) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/b/bf/Today_FM_Logo_2017.jpg"> | todayfm.com |
-|2 | 98FM | [>](https://stream.audioxi.com/98) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/98FM_2022.svg/1920px-98FM_2022.svg.png" /> | 98fm.com |
+| 1 | Today FM | [>](https://live-bauerie.sharp-stream.com/TDAAC) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/b/bf/Today_FM_Logo_2017.jpg"> | todayfm.com |
+|2 | 98FM | [>](https://live-bauerie.sharp-stream.com/98) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/98FM_2022.svg/1920px-98FM_2022.svg.png" /> | 98fm.com |
 | 3 | FM104 | [>](https://onic.dublin.live.stream.broadcasting.news/stream-fm104) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/c/cb/FM104_logo_tile.png" /> | fm104.ie |
 | 4 | Radio Nova | [>](https://playerservices.streamtheworld.com/api/livestream-redirect/RADIONOVA.mp3) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/a/a1/Nova-web1-228x150.jpg" /> | www.nova.ie |
-| 5 | Spin 103.8 | [>](https://stream.audioxi.com/SP) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/2/2e/Spin_400x400.png" /> | spin1038.com |
-| 6 | Newstalk | [>](https://stream.audioxi.com/NT) | <img height="20" src="" /> | newstalk.com
+| 5 | Spin 103.8 | [>](https://live-bauerie.sharp-stream.com/SP) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/2/2e/Spin_400x400.png" /> | spin1038.com |
+| 6 | Newstalk | [>](https://live-bauerie.sharp-stream.com/NT) | <img height="20" src="" /> | newstalk.com
 | 7 | Dublin's Q102  | [>](https://onic.dublin.live.stream.broadcasting.news/stream-q102) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/e/e7/Dublins_Q102_Logo.png" /> | q102.ie |
-| 8 | Classic Hits | [>](https://stream.audioxi.com/CLASSIC) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/3/31/Classichits2023.jpg" /> | classichits.ie |
-| 9 | Sunshine 106.8 | [>](https://live-bauerie.sharp-stream.com/SUN) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/9/97/Sunshine_106.8_logo.png" /> | sunshineradio.ie |
+| 8 | Classic Hits | [>](https://live-bauerie.sharp-stream.com/CLASSIC) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/3/31/Classichits2023.jpg" /> | classichits.ie |
+| 9 | Sunshine 106.8 | [>](https://playerservices.streamtheworld.com/api/livestream-redirect/SUNSHINE_106_8.mp3) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/9/97/Sunshine_106.8_logo.png" /> | sunshineradio.ie |
 
 <h2>Invalid</h2>
 

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -1286,23 +1286,23 @@ https://fastly.live.brightcove.com/6384196213112/eu-west-1/1555966122001/eyJhbGc
 #EXTINF:-1 tvg-name="Houses of the Oireachtas Channel" tvg-logo="https://i.imgur.com/aC4fsCI.png" tvg-id="OireachtasTV.ie" tvg-chno="22" tvg-country="IE" group-title="Ireland",Houses of the Oireachtas Channel
 https://d33zah5htxvoxb.cloudfront.net/el/live/oirtv/hls.m3u8
 #EXTINF:-1 tvg-name="Today FM" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/b/bf/Today_FM_Logo_2017.jpg" tvg-id="todayfm.com" tvg-chno="1" tvg-country="IE" group-title="Ireland",Today FM
-https://stream.audioxi.com/TDAAC
+https://live-bauerie.sharp-stream.com/TDAAC
 #EXTINF:-1 tvg-name="98FM" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/98FM_2022.svg/1920px-98FM_2022.svg.png" tvg-id="98fm.com" tvg-chno="2" tvg-country="IE" group-title="Ireland",98FM
-https://stream.audioxi.com/98
+https://live-bauerie.sharp-stream.com/98
 #EXTINF:-1 tvg-name="FM104" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cb/FM104_logo_tile.png" tvg-id="fm104.ie" tvg-chno="3" tvg-country="IE" group-title="Ireland",FM104
 https://onic.dublin.live.stream.broadcasting.news/stream-fm104
 #EXTINF:-1 tvg-name="Radio Nova" tvg-logo="https://upload.wikimedia.org/wikipedia/en/a/a1/Nova-web1-228x150.jpg" tvg-id="www.nova.ie" tvg-chno="4" tvg-country="IE" group-title="Ireland",Radio Nova
 https://playerservices.streamtheworld.com/api/livestream-redirect/RADIONOVA.mp3
 #EXTINF:-1 tvg-name="Spin 103.8" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/2/2e/Spin_400x400.png" tvg-id="spin1038.com" tvg-chno="5" tvg-country="IE" group-title="Ireland",Spin 103.8
-https://stream.audioxi.com/SP
+https://live-bauerie.sharp-stream.com/SP
 #EXTINF:-1 tvg-name="Newstalk" tvg-logo="" tvg-chno="6" tvg-country="IE" group-title="Ireland",Newstalk
-https://stream.audioxi.com/NT
+https://live-bauerie.sharp-stream.com/NT
 #EXTINF:-1 tvg-name="Dublin's Q102" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/e/e7/Dublins_Q102_Logo.png" tvg-id="q102.ie" tvg-chno="7" tvg-country="IE" group-title="Ireland",Dublin's Q102
 https://onic.dublin.live.stream.broadcasting.news/stream-q102
 #EXTINF:-1 tvg-name="Classic Hits" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/3/31/Classichits2023.jpg" tvg-id="classichits.ie" tvg-chno="8" tvg-country="IE" group-title="Ireland",Classic Hits
-https://stream.audioxi.com/CLASSIC
+https://live-bauerie.sharp-stream.com/CLASSIC
 #EXTINF:-1 tvg-name="Sunshine 106.8" tvg-logo="https://upload.wikimedia.org/wikipedia/en/9/97/Sunshine_106.8_logo.png" tvg-id="sunshineradio.ie" tvg-chno="9" tvg-country="IE" group-title="Ireland",Sunshine 106.8
-https://live-bauerie.sharp-stream.com/SUN
+https://playerservices.streamtheworld.com/api/livestream-redirect/SUNSHINE_106_8.mp3
 #EXTINF:-1 tvg-name="RTÉ One" tvg-logo="https://upload.wikimedia.org/wikipedia/en/thumb/e/e4/RT%C3%89_One_2014.svg/500px-RT%C3%89_One_2014.svg.png" tvg-id="RTEOne.ie" tvg-chno="1" tvg-country="IE" group-title="Ireland",RTÉ One
 https://live.rte.ie/live/a/channel1/channel1.isml/channel1.m3u8
 #EXTINF:-1 tvg-name="RTÉ2" tvg-logo="https://upload.wikimedia.org/wikipedia/en/thumb/1/11/RT%C3%892_logo.svg/500px-RT%C3%892_logo.svg.png" tvg-id="RTE2.ie" tvg-chno="2" tvg-country="IE" group-title="Ireland",RTÉ2

--- a/playlists/playlist_ireland.m3u8
+++ b/playlists/playlist_ireland.m3u8
@@ -4,23 +4,23 @@ https://fastly.live.brightcove.com/6384196213112/eu-west-1/1555966122001/eyJhbGc
 #EXTINF:-1 tvg-name="Houses of the Oireachtas Channel" tvg-logo="https://i.imgur.com/aC4fsCI.png" tvg-id="OireachtasTV.ie" tvg-chno="22" tvg-country="IE" group-title="Ireland",Houses of the Oireachtas Channel
 https://d33zah5htxvoxb.cloudfront.net/el/live/oirtv/hls.m3u8
 #EXTINF:-1 tvg-name="Today FM" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/b/bf/Today_FM_Logo_2017.jpg" tvg-id="todayfm.com" tvg-chno="1" tvg-country="IE" group-title="Ireland",Today FM
-https://stream.audioxi.com/TDAAC
+https://live-bauerie.sharp-stream.com/TDAAC
 #EXTINF:-1 tvg-name="98FM" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/98FM_2022.svg/1920px-98FM_2022.svg.png" tvg-id="98fm.com" tvg-chno="2" tvg-country="IE" group-title="Ireland",98FM
-https://stream.audioxi.com/98
+https://live-bauerie.sharp-stream.com/98
 #EXTINF:-1 tvg-name="FM104" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cb/FM104_logo_tile.png" tvg-id="fm104.ie" tvg-chno="3" tvg-country="IE" group-title="Ireland",FM104
 https://onic.dublin.live.stream.broadcasting.news/stream-fm104
 #EXTINF:-1 tvg-name="Radio Nova" tvg-logo="https://upload.wikimedia.org/wikipedia/en/a/a1/Nova-web1-228x150.jpg" tvg-id="www.nova.ie" tvg-chno="4" tvg-country="IE" group-title="Ireland",Radio Nova
 https://playerservices.streamtheworld.com/api/livestream-redirect/RADIONOVA.mp3
 #EXTINF:-1 tvg-name="Spin 103.8" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/2/2e/Spin_400x400.png" tvg-id="spin1038.com" tvg-chno="5" tvg-country="IE" group-title="Ireland",Spin 103.8
-https://stream.audioxi.com/SP
+https://live-bauerie.sharp-stream.com/SP
 #EXTINF:-1 tvg-name="Newstalk" tvg-logo="" tvg-chno="6" tvg-country="IE" group-title="Ireland",Newstalk
-https://stream.audioxi.com/NT
+https://live-bauerie.sharp-stream.com/NT
 #EXTINF:-1 tvg-name="Dublin's Q102" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/e/e7/Dublins_Q102_Logo.png" tvg-id="q102.ie" tvg-chno="7" tvg-country="IE" group-title="Ireland",Dublin's Q102
 https://onic.dublin.live.stream.broadcasting.news/stream-q102
 #EXTINF:-1 tvg-name="Classic Hits" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/3/31/Classichits2023.jpg" tvg-id="classichits.ie" tvg-chno="8" tvg-country="IE" group-title="Ireland",Classic Hits
-https://stream.audioxi.com/CLASSIC
+https://live-bauerie.sharp-stream.com/CLASSIC
 #EXTINF:-1 tvg-name="Sunshine 106.8" tvg-logo="https://upload.wikimedia.org/wikipedia/en/9/97/Sunshine_106.8_logo.png" tvg-id="sunshineradio.ie" tvg-chno="9" tvg-country="IE" group-title="Ireland",Sunshine 106.8
-https://live-bauerie.sharp-stream.com/SUN
+https://playerservices.streamtheworld.com/api/livestream-redirect/SUNSHINE_106_8.mp3
 #EXTINF:-1 tvg-name="RTÉ One" tvg-logo="https://upload.wikimedia.org/wikipedia/en/thumb/e/e4/RT%C3%89_One_2014.svg/500px-RT%C3%89_One_2014.svg.png" tvg-id="RTEOne.ie" tvg-chno="1" tvg-country="IE" group-title="Ireland",RTÉ One
 https://live.rte.ie/live/a/channel1/channel1.isml/channel1.m3u8
 #EXTINF:-1 tvg-name="RTÉ2" tvg-logo="https://upload.wikimedia.org/wikipedia/en/thumb/1/11/RT%C3%892_logo.svg/500px-RT%C3%892_logo.svg.png" tvg-id="RTE2.ie" tvg-chno="2" tvg-country="IE" group-title="Ireland",RTÉ2


### PR DESCRIPTION
Root cause: Bauer Media Audio Ireland (Today FM, 98FM, Newstalk, Spin 1038, Classic Hits) migrated their stream infrastructure from `stream.audioxi.com` to `live-bauerie.sharp-stream.com` (same mount names, new host), found via their `goloudplayer.com` player pages. Sunshine 106.8 moved off sharp-stream onto `streamtheworld.com` (shared player config with Nova and Classic Hits' own sites).

FM104 and Dublin's Q102 URLs are unchanged - re-verified returning real audio, likely a transient outage rather than a dead link.

Note: verified for real audio content (bytes + correct `Content-Type`) directly with curl, since `check_channels.py`'s history at this point doesn't yet recognize raw audio streams as alive (see #1169).