### PR TITLE
Fix dead TV 7 Albania and TV Apollon links

### DIFF
--- a/lists/albania.md
+++ b/lists/albania.md
@@ -25,6 +25,6 @@
 | 0  | Syri | [>](https://stream.syritv.al/live/syritv/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4zVyj1M.png"/> | Syri.al |
 | 0  | Top News Ⓣ | [>](https://www.twitch.tv/topnewsal) | <img height="20" src="https://i.imgur.com/tBAXkOW.png"/> | TopNews.al |
 | 0  | Tropoja | [>](https://live.prostream.al/al/smil:tropojatv.smil/playlist.m3u8) | <img height="20" src="https://i.imgur.com/D3hNOVS.png"/> | TropojaTelevizion.al |
-| 0  | TV 7 Albania | [>](https://vs.sednastream.com:1936/tv7/tv7/playlist.m3u8) | <img height="20" src="https://i.imgur.com/k9WqPLZ.png"/> | TV7Albania.al |
-| 0  | TV Apollon Ⓢ | [>](https://live.apollon.tv/Apollon-WEB/video.m3u8?token=tnt3u76re30d2) | <img height="20" src="https://i.imgur.com/gUz2AjM.png"/> | TVApollon.al |
+| 0  | TV 7 Albania | [>](https://rpn3.bozztv.com/albaniatv/Med7-TV7Tirana/index.m3u8) | <img height="20" src="https://i.imgur.com/k9WqPLZ.png"/> | TV7Albania.al |
+| 0  | TV Apollon Ⓢ | [>](https://live.apollon.tv/Apollon-Web/video.m3u8?token=tnt9u76reF0d1) | <img height="20" src="https://i.imgur.com/gUz2AjM.png"/> | TVApollon.al |
 | 0  | Vizion Plus | [>](https://tringliveviz.akamaized.net/delta/105/out/u/qwaszxerdfcvrtryuy.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Vizion_Plus.svg/500px-Vizion_Plus.svg.png"/> | VizionPlus.al |

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -28,9 +28,9 @@ https://www.twitch.tv/topnewsal
 #EXTINF:-1 tvg-name="Tropoja" tvg-logo="https://i.imgur.com/D3hNOVS.png" tvg-id="TropojaTelevizion.al" tvg-country="AL" group-title="Albania",Tropoja
 https://live.prostream.al/al/smil:tropojatv.smil/playlist.m3u8
 #EXTINF:-1 tvg-name="TV 7 Albania" tvg-logo="https://i.imgur.com/k9WqPLZ.png" tvg-id="TV7Albania.al" tvg-country="AL" group-title="Albania",TV 7 Albania
-https://vs.sednastream.com:1936/tv7/tv7/playlist.m3u8
+https://rpn3.bozztv.com/albaniatv/Med7-TV7Tirana/index.m3u8
 #EXTINF:-1 tvg-name="TV Apollon" tvg-logo="https://i.imgur.com/gUz2AjM.png" tvg-id="TVApollon.al" tvg-country="AL" group-title="Albania",TV Apollon Ⓢ
-https://live.apollon.tv/Apollon-WEB/video.m3u8?token=tnt3u76re30d2
+https://live.apollon.tv/Apollon-Web/video.m3u8?token=tnt9u76reF0d1
 #EXTINF:-1 tvg-name="Vizion Plus" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Vizion_Plus.svg/500px-Vizion_Plus.svg.png" tvg-id="VizionPlus.al" tvg-country="AL" group-title="Albania",Vizion Plus
 https://tringliveviz.akamaized.net/delta/105/out/u/qwaszxerdfcvrtryuy.m3u8
 #EXTINF:-1 tvg-name="Andorra TV" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/3/32/Logo_Andorra_Televisi%C3%B3.png" tvg-id="AndorraTV.ad" tvg-chno="1" tvg-country="AD" group-title="Andorra",Andorra TV

--- a/playlists/playlist_albania.m3u8
+++ b/playlists/playlist_albania.m3u8
@@ -28,8 +28,8 @@ https://www.twitch.tv/topnewsal
 #EXTINF:-1 tvg-name="Tropoja" tvg-logo="https://i.imgur.com/D3hNOVS.png" tvg-id="TropojaTelevizion.al" tvg-country="AL" group-title="Albania",Tropoja
 https://live.prostream.al/al/smil:tropojatv.smil/playlist.m3u8
 #EXTINF:-1 tvg-name="TV 7 Albania" tvg-logo="https://i.imgur.com/k9WqPLZ.png" tvg-id="TV7Albania.al" tvg-country="AL" group-title="Albania",TV 7 Albania
-https://vs.sednastream.com:1936/tv7/tv7/playlist.m3u8
+https://rpn3.bozztv.com/albaniatv/Med7-TV7Tirana/index.m3u8
 #EXTINF:-1 tvg-name="TV Apollon" tvg-logo="https://i.imgur.com/gUz2AjM.png" tvg-id="TVApollon.al" tvg-country="AL" group-title="Albania",TV Apollon Ⓢ
-https://live.apollon.tv/Apollon-WEB/video.m3u8?token=tnt3u76re30d2
+https://live.apollon.tv/Apollon-Web/video.m3u8?token=tnt9u76reF0d1
 #EXTINF:-1 tvg-name="Vizion Plus" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Vizion_Plus.svg/500px-Vizion_Plus.svg.png" tvg-id="VizionPlus.al" tvg-country="AL" group-title="Albania",Vizion Plus
 https://tringliveviz.akamaized.net/delta/105/out/u/qwaszxerdfcvrtryuy.m3u8


### PR DESCRIPTION
## Albania
- **TV 7 Albania**: `vs.sednastream.com:1936` returns HTTP 403. Found the station's current feed via its official site's live embed (tv7.al → swf.tulix.tv iframe), backed by bozztv.com. Verified alive via local checker (3/3 ok), real HLS media playlist with rolling segments.
- **TV Apollon**: the stored token in the old URL is stale (404, wrong path casing). Found the current token+path hardcoded in the station's own live player JS on apollon.tv. Verified alive via local checker (3/3 ok), real live playlist with current-timestamped segments.

## Researched but left unchanged
No viable replacement found within reasonable effort — documented for future reference:
- **Albania**: Kanali 7, Alpo TV, Panorama TV, Report TV — official sites either have no public video stream, sit behind a Cloudflare JS challenge, or the stream host itself is unreachable.
- **Bulgaria** (bTV, Nova TV, Bulgaria On Air, Nova News, BNT1-4): official infrastructure appears to be Bulgaria-ISP-local or geo-blocked; Nova's own embed uses a per-request, IP-bound, time-limited signed URL, not usable as a static playlist entry.
- **Georgia** (Adjara TV, Maestro TV, Mtavari Arkhi, GDS, Pos TV, Obieqtivi): official domains are down, parked/expired, or return gateway errors even on the broadcaster's own site.

Regenerated `playlist.m3u8` and `playlists/playlist_albania.m3u8` via `make_playlist.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enus8N247jHM5r5Som5JuU