### PR TITLE
Fix dead NTV Kenya, Kibris TV, TV 2020, and Telefe links

### DIFF
--- a/lists/argentina.md
+++ b/lists/argentina.md
@@ -36,7 +36,7 @@ https://en.wikipedia.org/wiki/List_of_television_stations_in_Argentina#Major_bro
 |32.3 | Comarca TV | [>](https://www.youtube.com/c/ComarcaTV/live)|<img height="20" src="http://directostv.teleame.com/wp-content/uploads/2020/10/Comarca-TV-en-vivo-Online.png" />|ComarcaTV.ar|
 | 33.1 | El Trece       | [>](https://livetrx01.vodgc.net/eltrecetv/index.m3u8) | <img height="20" src="https://i.imgur.com/ZK7AQFg.png"/> | ElTrece.ar |
 | 35.1 | El Nueve       | [>](http://45.226.28.9:8085/Live/18e292ea93b66c65c76707f07c489d61/local-canal9.playlist.m3u8) | <img height="20" src="https://i.imgur.com/EtcVSm4.png"/> | ElNueve.ar |
-| 34.1 | Telefe Ⓨ       | [>](https://telefe.com/Api/Videos/GetSourceUrl/694564/0/HLS?.m3u8) | <img height="20" src="https://i.imgur.com/wrZfMXn.png"/> | Telefe.ar |
+| 34.1 | Telefe         | [>](http://45.134.141.161:2200/ARG/TELEFE_HD/index.m3u8) | <img height="20" src="https://i.imgur.com/wrZfMXn.png"/> | Telefe.ar |
 | 36.1 | América      | [>](https://prepublish.f.qaotic.net/a07/americahls-100056/playlist_720p.m3u8) | <img height="20" src="https://i.imgur.com/Jt7dOQm.png"/> | AmericaTV.ar |
 | 36.2 | A24 Ⓨ          | [>](https://www.youtube.com/c/A24com/live) | <img height="20" src="https://i.imgur.com/OdhF7ym.png"/> | A24.ar |
 <h2>Invalid</h2>

--- a/lists/cyprus.md
+++ b/lists/cyprus.md
@@ -23,5 +23,5 @@
 | 2   | BRT 2 | [x](https://sc-kuzeykibrissmarttv.ercdn.net/brt2hd/bant1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/t5kbIuj.png"/> | BRT2.cy |
 | 4   | Kibris Genc TV | [x](https://sc-kuzeykibrissmarttv.ercdn.net/kibrisgenctv/bant1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/eBdQn9h.png"/> | KibrisGencTV.cy |
 | 5   | Kanal T | [x](https://sc-kuzeykibrissmarttv.ercdn.net/kanalt/bantp1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/4bA4pXT.png"/> | KibrisKanalT.cy |
-| 6   | Kibris TV | [x](https://sc-kuzeykibrissmarttv.ercdn.net/kibristv/bant1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/5MJZPTo.png"/> | KibrisTV.cy |
-| 7   | TV 2020 | [x](https://sc-kuzeykibrissmarttv.ercdn.net/tv2020/bantp1/playlist.m3u8) | <img height="20" src="https://i.imgur.com/rtfsNdd.png"/> | TV2020.cy |
+| 6   | Kibris TV | [>](https://old.kuzeykibris.tv/m3u8/kktv.m3u8) | <img height="20" src="https://i.imgur.com/5MJZPTo.png"/> | KibrisTV.cy |
+| 7   | TV 2020 Ⓨ | [>](https://www.youtube.com/@TV2020KIBRIS/live) | <img height="20" src="https://i.imgur.com/rtfsNdd.png"/> | TV2020.cy |

--- a/lists/kenya.md
+++ b/lists/kenya.md
@@ -4,6 +4,6 @@
 |:---:|:--------------:|:-----:|:----:|:------:|
 | 1 | KTN NEWS TV | [>](https://www.standardmedia.co.ke/ktnnews/live) | <img height="20" src="https://i.imgur.com/7yzunBK.png"/> | KTNNews.ke |
 | 2 | Citizen TV | [>](https://citizentv.co.ke/live) | <img height="20" src="https://i.imgur.com/DjDaD7h.png"/> | CitizenTV.ke |
-| 3 | NTV Kenya | [>](https://nation.africa/kenya/tv/live) | <img height="20" src="https://i.imgur.com/OpoLjfv"/> | NTV.ke |
+| 3 | NTV Kenya Ⓨ | [>](https://www.youtube.com/c/NTVKenyaOnline/live) | <img height="20" src="https://i.imgur.com/OpoLjfv"/> | NTV.ke |
 | 4 | KTN Home | [>](https://www.standardmedia.co.ke/ktnhome/live) | <img height="20" src="https://i.imgur.com/7yzunBK.png"/> | KTNHome.ke |
 | 5 | K24 TV | [>](https://livecdn.premiumfree.tv/afxpstr/K24Backup/index.m3u8) | <img height="20" src="https://i.imgur.com/ce2P9Y4"/> | K24.ke |

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -81,8 +81,8 @@ https://www.youtube.com/c/ComarcaTV/live
 https://livetrx01.vodgc.net/eltrecetv/index.m3u8
 #EXTINF:-1 tvg-name="El Nueve" tvg-logo="https://i.imgur.com/EtcVSm4.png" tvg-id="ElNueve.ar" tvg-chno="35.1" tvg-country="AR" group-title="Argentina",El Nueve
 http://45.226.28.9:8085/Live/18e292ea93b66c65c76707f07c489d61/local-canal9.playlist.m3u8
-#EXTINF:-1 tvg-name="Telefe" tvg-logo="https://i.imgur.com/wrZfMXn.png" tvg-id="Telefe.ar" tvg-chno="34.1" tvg-country="AR" group-title="Argentina",Telefe Ⓨ
-https://telefe.com/Api/Videos/GetSourceUrl/694564/0/HLS?.m3u8
+#EXTINF:-1 tvg-name="Telefe" tvg-logo="https://i.imgur.com/wrZfMXn.png" tvg-id="Telefe.ar" tvg-chno="34.1" tvg-country="AR" group-title="Argentina",Telefe
+http://45.134.141.161:2200/ARG/TELEFE_HD/index.m3u8
 #EXTINF:-1 tvg-name="América" tvg-logo="https://i.imgur.com/Jt7dOQm.png" tvg-id="AmericaTV.ar" tvg-chno="36.1" tvg-country="AR" group-title="Argentina",América
 https://prepublish.f.qaotic.net/a07/americahls-100056/playlist_720p.m3u8
 #EXTINF:-1 tvg-name="A24" tvg-logo="https://i.imgur.com/OdhF7ym.png" tvg-id="A24.ar" tvg-chno="36.2" tvg-country="AR" group-title="Argentina",A24 Ⓨ
@@ -525,6 +525,10 @@ http://213.7.216.229:8888/udp/239.23.0.5:1234
 https://l3.cloudskep.com/cybcsat/abr/playlist.m3u8
 #EXTINF:-1 tvg-name="Ada TV" tvg-logo="https://i.imgur.com/LPQfdz2.png" tvg-id="AdaTV.cy" tvg-chno="3" tvg-country="CY" group-title="Cyprus",Ada TV
 https://yayin1.canlitv.fun/live/kibrisadatv.stream/playlist.m3u8
+#EXTINF:-1 tvg-name="Kibris TV" tvg-logo="https://i.imgur.com/5MJZPTo.png" tvg-id="KibrisTV.cy" tvg-chno="6" tvg-country="CY" group-title="Cyprus",Kibris TV
+https://old.kuzeykibris.tv/m3u8/kktv.m3u8
+#EXTINF:-1 tvg-name="TV 2020" tvg-logo="https://i.imgur.com/rtfsNdd.png" tvg-id="TV2020.cy" tvg-chno="7" tvg-country="CY" group-title="Cyprus",TV 2020 Ⓨ
+https://www.youtube.com/@TV2020KIBRIS/live
 #EXTINF:-1 tvg-name="ČT1" tvg-logo="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/czech-republic/ct1-cz.png" tvg-id="CT1.cz" tvg-chno="1" tvg-country="CZ" group-title="Czech Republic",ČT1
 http://88.212.15.19/live/test_ct1_25p/playlist.m3u8
 #EXTINF:-1 tvg-name="ČT2" tvg-logo="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/czech-republic/ct2-cz.png" tvg-id="CT2.cz" tvg-chno="2" tvg-country="CZ" group-title="Czech Republic",ČT2
@@ -2253,8 +2257,8 @@ http://stream.mcquack.net/72/index.m3u8
 https://www.standardmedia.co.ke/ktnnews/live
 #EXTINF:-1 tvg-name="Citizen TV" tvg-logo="https://i.imgur.com/DjDaD7h.png" tvg-id="CitizenTV.ke" tvg-chno="2" tvg-country="KE" group-title="Kenya",Citizen TV
 https://citizentv.co.ke/live
-#EXTINF:-1 tvg-name="NTV Kenya" tvg-logo="https://i.imgur.com/OpoLjfv" tvg-id="NTV.ke" tvg-chno="3" tvg-country="KE" group-title="Kenya",NTV Kenya
-https://nation.africa/kenya/tv/live
+#EXTINF:-1 tvg-name="NTV Kenya" tvg-logo="https://i.imgur.com/OpoLjfv" tvg-id="NTV.ke" tvg-chno="3" tvg-country="KE" group-title="Kenya",NTV Kenya Ⓨ
+https://www.youtube.com/c/NTVKenyaOnline/live
 #EXTINF:-1 tvg-name="KTN Home" tvg-logo="https://i.imgur.com/7yzunBK.png" tvg-id="KTNHome.ke" tvg-chno="4" tvg-country="KE" group-title="Kenya",KTN Home
 https://www.standardmedia.co.ke/ktnhome/live
 #EXTINF:-1 tvg-name="K24 TV" tvg-logo="https://i.imgur.com/ce2P9Y4" tvg-id="K24.ke" tvg-chno="5" tvg-country="KE" group-title="Kenya",K24 TV

--- a/playlists/playlist_argentina.m3u8
+++ b/playlists/playlist_argentina.m3u8
@@ -45,8 +45,8 @@ https://www.youtube.com/c/ComarcaTV/live
 https://livetrx01.vodgc.net/eltrecetv/index.m3u8
 #EXTINF:-1 tvg-name="El Nueve" tvg-logo="https://i.imgur.com/EtcVSm4.png" tvg-id="ElNueve.ar" tvg-chno="35.1" tvg-country="AR" group-title="Argentina",El Nueve
 http://45.226.28.9:8085/Live/18e292ea93b66c65c76707f07c489d61/local-canal9.playlist.m3u8
-#EXTINF:-1 tvg-name="Telefe" tvg-logo="https://i.imgur.com/wrZfMXn.png" tvg-id="Telefe.ar" tvg-chno="34.1" tvg-country="AR" group-title="Argentina",Telefe Ⓨ
-https://telefe.com/Api/Videos/GetSourceUrl/694564/0/HLS?.m3u8
+#EXTINF:-1 tvg-name="Telefe" tvg-logo="https://i.imgur.com/wrZfMXn.png" tvg-id="Telefe.ar" tvg-chno="34.1" tvg-country="AR" group-title="Argentina",Telefe
+http://45.134.141.161:2200/ARG/TELEFE_HD/index.m3u8
 #EXTINF:-1 tvg-name="América" tvg-logo="https://i.imgur.com/Jt7dOQm.png" tvg-id="AmericaTV.ar" tvg-chno="36.1" tvg-country="AR" group-title="Argentina",América
 https://prepublish.f.qaotic.net/a07/americahls-100056/playlist_720p.m3u8
 #EXTINF:-1 tvg-name="A24" tvg-logo="https://i.imgur.com/OdhF7ym.png" tvg-id="A24.ar" tvg-chno="36.2" tvg-country="AR" group-title="Argentina",A24 Ⓨ

--- a/playlists/playlist_cyprus.m3u8
+++ b/playlists/playlist_cyprus.m3u8
@@ -9,3 +9,7 @@ http://213.7.216.229:8888/udp/239.23.0.5:1234
 https://l3.cloudskep.com/cybcsat/abr/playlist.m3u8
 #EXTINF:-1 tvg-name="Ada TV" tvg-logo="https://i.imgur.com/LPQfdz2.png" tvg-id="AdaTV.cy" tvg-chno="3" tvg-country="CY" group-title="Cyprus",Ada TV
 https://yayin1.canlitv.fun/live/kibrisadatv.stream/playlist.m3u8
+#EXTINF:-1 tvg-name="Kibris TV" tvg-logo="https://i.imgur.com/5MJZPTo.png" tvg-id="KibrisTV.cy" tvg-chno="6" tvg-country="CY" group-title="Cyprus",Kibris TV
+https://old.kuzeykibris.tv/m3u8/kktv.m3u8
+#EXTINF:-1 tvg-name="TV 2020" tvg-logo="https://i.imgur.com/rtfsNdd.png" tvg-id="TV2020.cy" tvg-chno="7" tvg-country="CY" group-title="Cyprus",TV 2020 Ⓨ
+https://www.youtube.com/@TV2020KIBRIS/live

--- a/playlists/playlist_kenya.m3u8
+++ b/playlists/playlist_kenya.m3u8
@@ -3,8 +3,8 @@
 https://www.standardmedia.co.ke/ktnnews/live
 #EXTINF:-1 tvg-name="Citizen TV" tvg-logo="https://i.imgur.com/DjDaD7h.png" tvg-id="CitizenTV.ke" tvg-chno="2" tvg-country="KE" group-title="Kenya",Citizen TV
 https://citizentv.co.ke/live
-#EXTINF:-1 tvg-name="NTV Kenya" tvg-logo="https://i.imgur.com/OpoLjfv" tvg-id="NTV.ke" tvg-chno="3" tvg-country="KE" group-title="Kenya",NTV Kenya
-https://nation.africa/kenya/tv/live
+#EXTINF:-1 tvg-name="NTV Kenya" tvg-logo="https://i.imgur.com/OpoLjfv" tvg-id="NTV.ke" tvg-chno="3" tvg-country="KE" group-title="Kenya",NTV Kenya Ⓨ
+https://www.youtube.com/c/NTVKenyaOnline/live
 #EXTINF:-1 tvg-name="KTN Home" tvg-logo="https://i.imgur.com/7yzunBK.png" tvg-id="KTNHome.ke" tvg-chno="4" tvg-country="KE" group-title="Kenya",KTN Home
 https://www.standardmedia.co.ke/ktnhome/live
 #EXTINF:-1 tvg-name="K24 TV" tvg-logo="https://i.imgur.com/ce2P9Y4" tvg-id="K24.ke" tvg-chno="5" tvg-country="KE" group-title="Kenya",K24 TV


### PR DESCRIPTION
## Kenya
- **NTV Kenya**: `nation.africa/kenya/tv/live` 404s. Their live simulcast is on the station's own official YouTube channel (linked from ntvkenya.co.ke itself); confirmed actually live at verification time (canonical URL resolved to a `/watch?v=` page, not the channel page).

## Cyprus
- **Kibris TV**: the shared `sc-kuzeykibrissmarttv.ercdn.net` CDN is gone (DNS NXDOMAIN) for all 6 TRNC channels in this section. Found Kibris TV's current feed via a Northern Cyprus web-TV aggregator (old.kuzeykibris.tv), a real rolling HLS media playlist. Verified alive via local checker (3/3 ok).
- **TV 2020**: same dead CDN. Its official YouTube channel is confirmed live now. BRT 1, BRT 2, and Kibris Genc TV/Kanal T were also researched, but their YouTube channels were NOT live at verification time (canonical stayed on the channel page) — left unchanged rather than adding an unreliable "channel not live" link.

## Argentina
- **Telefe**: the old telefe.com API endpoint is deprecated (redirects to mitelefe.com, whose live-stream URL is now fetched client-side by JS and not extractable via curl). Replaced with a verified-alive third-party restream, the same pattern already used for other channels in this file (e.g. El Nueve's raw-IP entry). Flagged here as a fallback, not an official source.
- **Aunar, Cine.AR, Tec TV, DeporTV**: researched, all confirmed genuinely dead at their own official infrastructure (squatted/parked domains, VOD-only platforms, abandoned servers) with no live YouTube simulcast either — left unchanged, no fix available.

Regenerated `playlist.m3u8` and the per-country playlists via `make_playlist.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enus8N247jHM5r5Som5JuU
