### PR TITLE
Only fail the PR channel check on channels the PR itself broke

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -63,8 +63,12 @@ jobs:
             echo "No list files exist to check (this PR only removed lists) - nothing to do." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          # check_channels.py's own exit code reflects every dead channel in these lists,
+          # including ones this PR never touched - that's not this job's call to make, so
+          # it's deliberately ignored here. The next step decides pass/fail from the
+          # PR-touched channels only.
           # shellcheck disable=SC2086
-          python3 check_channels.py $lists --attempts 2 --timeout 10 --pause 2 --workers 30 --json pr_run.jsonl
+          python3 check_channels.py $lists --attempts 2 --timeout 10 --pause 2 --workers 30 --json pr_run.jsonl || true
 
       - name: Summarize, separating what this PR touched from what was already there
         if: always()
@@ -95,6 +99,12 @@ jobs:
               lines = [f'{r["state"]:12} {r["list"]:12} {r["channel"]} -> {r["url"]}' for r in ordered]
               return "\n".join(lines) or "(none)"
 
+          # only a channel this PR itself added or changed can fail the check - and only
+          # for a clear-cut `dead` verdict. `blocked`/`unreachable`/`flaky` have too many
+          # false positives from this runner's own network (geo-blocks, a datacenter IP
+          # some providers reject, one slow probe) to gate a merge on.
+          newly_dead = [r for r in touched if r["state"] == "dead"]
+
           lists_seen = ", ".join(sorted({r["list"] for r in rows})) or "(none)"
           with open(summary_path, "a", encoding="utf-8") as handle:
               handle.write("## PR channel check\n\n")
@@ -114,4 +124,12 @@ jobs:
                   "*Channel check (deep)* workflow gives channels that look `dead` here one more "
                   "chance before anyone acts on it. Use your judgment either way._\n"
               )
+              if newly_dead:
+                  handle.write(
+                      f"\n**This check fails: {len(newly_dead)} channel(s) added or changed by "
+                      "this PR look dead.** See the list above.\n"
+                  )
+
+          if newly_dead:
+              raise SystemExit(1)
           PYEOF


### PR DESCRIPTION
`check_channels.py`'s exit code reflects every dead channel across the whole list file it was pointed at, not just the ones a PR added or changed. Since `pr_check.yml` ran the checker directly and let its exit code decide the job's pass/fail, any PR touching a list that already had pre-existing dead entries (which is most of them) got a red X for something it never caused — even though the workflow's own summary step already computes the right "touched vs already broken" split, it just never got to act on that distinction.

## Fix
- The check step now runs to completion regardless of its own exit code (the checker's verdict on the *whole* file isn't this job's call to make).
- Pass/fail moves into the summarize step, which already has the touched/others split: the job now fails only when a channel this PR itself added or changed comes back `dead`.
- Deliberately not failing on `blocked`/`unreachable`/`flaky` for touched channels either — these have real false-positive rates from the runner's own network (geo-blocks, a datacenter IP some providers reject, one slow probe), which is exactly why the *Channel check (deep)* workflow exists: to give `dead`-looking channels a second opinion before anyone acts on them.

Observed in practice on #1173, #1174, #1175: all three got a red X purely from pre-existing dead entries in the touched files, with the PR's own changes verified alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enus8N247jHM5r5Som5JuU
