### PR TITLE
Fix dead LiveNOW from FOX and RTS 3 links

### DIFF
--- a/lists/serbia.md
+++ b/lists/serbia.md
@@ -4,7 +4,7 @@
 |:---:|:--------------:|:-----:|:----:|:------:|
 | 1 | RTS 1 | [>](https://webtvstream.bhtelecom.ba/rts1.m3u8) | <img height="20" src="https://i.imgur.com/S1pKHSR.png"/> | RTS1.rs |
 | 2 | RTS 2 | [>](https://webtvstream.bhtelecom.ba/rts2.m3u8) | <img height="20" src="https://i.imgur.com/jltAf5h.png"/> | RTS2.rs |
-| 3 | RTS 3 | [>](http://185.81.240.65:15000/udp/233.233.233.36:12000) | <img height="20" src="https://i.imgur.com/gxuGB4J.png"/> | RTS3.rs |
+| 3 | RTS 3 | [>](https://webtvstream.bhtelecom.ba/rts_sat.m3u8) | <img height="20" src="https://i.imgur.com/gxuGB4J.png"/> | RTS3.rs |
 | 4 | Red TV | [>](https://edge8.pink.rs/redtv/index.m3u8) | <img height="20" src="https://i.imgur.com/cpN7NrL.png"/> | RedTV.rs |
 | 5 | Kurir TV | [>](https://static.am.mediaoutcast.com/storage/nQJnjJkO/nQJnjJkO/stream/O68x4o8g/720p/720p.m3u8) | <img height="20" src="https://i.imgur.com/HBPnUD5.png"/> | KurirTV.rs |
 | 6 | Informer TV | [>](https://edge-rs-03.maksnet.tv/informertv-secure/web/playlist.m3u8) | <img height="20" src="https://i.imgur.com/9wdEHRf.png"/> | InformerTV.rs |

--- a/lists/zz_news_en.md
+++ b/lists/zz_news_en.md
@@ -15,7 +15,7 @@
 | 11 |    The Guardian     |  [>](https://rakuten-guardian-1-ie.samsung.wurl.tv/playlist.m3u8)  |  <img height="20" src="https://i.imgur.com/o9AYq9V.png"/>  |  TheGuardian.uk |
 | 12 |      CBS News       |  [>](https://dai.google.com/linear/hls/event/Sid4xiTQTkCT1SLu6rjUSQ/master.m3u8)  |  <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-states/cbs-news-us.png"/>  |  CBSNews.us |
 | 13 |    ABC News Live    |  [>](https://abcnews-streams.akamaized.net/hls/live/2023560/abcnewshudson1/master.m3u8)  |  <img height="20" src="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-states/abc-news-live-hz-us.png"/>  |  ABCNewsLive.us |
-| 14 |  LiveNOW from FOX   |  [>](https://lnc-fox-live-now.tubi.video/index.m3u8)  |  <img height="20" src="https://i.imgur.com/1JnyzHv.png"/>  |  LiveNOWFromFOX.us |
+| 14 |  LiveNOW from FOX   |  [>](https://fox-foxnewsnow-vizio.amagi.tv/playlist.m3u8)  |  <img height="20" src="https://i.imgur.com/1JnyzHv.png"/>  |  LiveNOWFromFOX.us |
 | 15 |  CBC News Network   |  [>](https://dai2.xumo.com/amagi_hls_data_xumo1212A-redboxcbcnews/CDN/playlist.m3u8)  |  <img height="20" src="https://i.imgur.com/SjTdhvJ.png"/>  |  CBCNewsNetwork.ca |
 | 16 |     Ticker News     |  [>](https://cdn-uw2-prod.tsv2.amagi.tv/linear/amg01486-tickernews-tickernewsweb-ono/playlist.m3u8)  |  <img height="20" src="https://i.imgur.com/z7M0QxV.png"/>   |  tickerNews.au  |
 | 17 |     India Today     |  [>](https://indiatodaylive.akamaized.net/hls/live/2014320/indiatoday/indiatodaylive/playlist.m3u8)  |  <img height="20" src="https://i.imgur.com/koFYddE.png"/>  |  IndiaToday.in |

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -2920,7 +2920,7 @@ https://webtvstream.bhtelecom.ba/rts1.m3u8
 #EXTINF:-1 tvg-name="RTS 2" tvg-logo="https://i.imgur.com/jltAf5h.png" tvg-id="RTS2.rs" tvg-chno="2" tvg-country="RS" group-title="Serbia",RTS 2
 https://webtvstream.bhtelecom.ba/rts2.m3u8
 #EXTINF:-1 tvg-name="RTS 3" tvg-logo="https://i.imgur.com/gxuGB4J.png" tvg-id="RTS3.rs" tvg-chno="3" tvg-country="RS" group-title="Serbia",RTS 3
-http://185.81.240.65:15000/udp/233.233.233.36:12000
+https://webtvstream.bhtelecom.ba/rts_sat.m3u8
 #EXTINF:-1 tvg-name="Red TV" tvg-logo="https://i.imgur.com/cpN7NrL.png" tvg-id="RedTV.rs" tvg-chno="4" tvg-country="RS" group-title="Serbia",Red TV
 https://edge8.pink.rs/redtv/index.m3u8
 #EXTINF:-1 tvg-name="Kurir TV" tvg-logo="https://i.imgur.com/HBPnUD5.png" tvg-id="KurirTV.rs" tvg-chno="5" tvg-country="RS" group-title="Serbia",Kurir TV
@@ -3702,7 +3702,7 @@ https://dai.google.com/linear/hls/event/Sid4xiTQTkCT1SLu6rjUSQ/master.m3u8
 #EXTINF:-1 tvg-name="ABC News Live" tvg-logo="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-states/abc-news-live-hz-us.png" tvg-id="ABCNewsLive.us" tvg-chno="13" group-title="News",ABC News Live
 https://abcnews-streams.akamaized.net/hls/live/2023560/abcnewshudson1/master.m3u8
 #EXTINF:-1 tvg-name="LiveNOW from FOX" tvg-logo="https://i.imgur.com/1JnyzHv.png" tvg-id="LiveNOWFromFOX.us" tvg-chno="14" group-title="News",LiveNOW from FOX
-https://lnc-fox-live-now.tubi.video/index.m3u8
+https://fox-foxnewsnow-vizio.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-name="CBC News Network" tvg-logo="https://i.imgur.com/SjTdhvJ.png" tvg-id="CBCNewsNetwork.ca" tvg-chno="15" group-title="News",CBC News Network
 https://dai2.xumo.com/amagi_hls_data_xumo1212A-redboxcbcnews/CDN/playlist.m3u8
 #EXTINF:-1 tvg-name="Ticker News" tvg-logo="https://i.imgur.com/z7M0QxV.png" tvg-id="tickerNews.au" tvg-chno="16" group-title="News",Ticker News

--- a/playlists/playlist_serbia.m3u8
+++ b/playlists/playlist_serbia.m3u8
@@ -4,7 +4,7 @@ https://webtvstream.bhtelecom.ba/rts1.m3u8
 #EXTINF:-1 tvg-name="RTS 2" tvg-logo="https://i.imgur.com/jltAf5h.png" tvg-id="RTS2.rs" tvg-chno="2" tvg-country="RS" group-title="Serbia",RTS 2
 https://webtvstream.bhtelecom.ba/rts2.m3u8
 #EXTINF:-1 tvg-name="RTS 3" tvg-logo="https://i.imgur.com/gxuGB4J.png" tvg-id="RTS3.rs" tvg-chno="3" tvg-country="RS" group-title="Serbia",RTS 3
-http://185.81.240.65:15000/udp/233.233.233.36:12000
+https://webtvstream.bhtelecom.ba/rts_sat.m3u8
 #EXTINF:-1 tvg-name="Red TV" tvg-logo="https://i.imgur.com/cpN7NrL.png" tvg-id="RedTV.rs" tvg-chno="4" tvg-country="RS" group-title="Serbia",Red TV
 https://edge8.pink.rs/redtv/index.m3u8
 #EXTINF:-1 tvg-name="Kurir TV" tvg-logo="https://i.imgur.com/HBPnUD5.png" tvg-id="KurirTV.rs" tvg-chno="5" tvg-country="RS" group-title="Serbia",Kurir TV

--- a/playlists/playlist_zz_news_en.m3u8
+++ b/playlists/playlist_zz_news_en.m3u8
@@ -26,7 +26,7 @@ https://dai.google.com/linear/hls/event/Sid4xiTQTkCT1SLu6rjUSQ/master.m3u8
 #EXTINF:-1 tvg-name="ABC News Live" tvg-logo="https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-states/abc-news-live-hz-us.png" tvg-id="ABCNewsLive.us" tvg-chno="13" group-title="News",ABC News Live
 https://abcnews-streams.akamaized.net/hls/live/2023560/abcnewshudson1/master.m3u8
 #EXTINF:-1 tvg-name="LiveNOW from FOX" tvg-logo="https://i.imgur.com/1JnyzHv.png" tvg-id="LiveNOWFromFOX.us" tvg-chno="14" group-title="News",LiveNOW from FOX
-https://lnc-fox-live-now.tubi.video/index.m3u8
+https://fox-foxnewsnow-vizio.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-name="CBC News Network" tvg-logo="https://i.imgur.com/SjTdhvJ.png" tvg-id="CBCNewsNetwork.ca" tvg-chno="15" group-title="News",CBC News Network
 https://dai2.xumo.com/amagi_hls_data_xumo1212A-redboxcbcnews/CDN/playlist.m3u8
 #EXTINF:-1 tvg-name="Ticker News" tvg-logo="https://i.imgur.com/z7M0QxV.png" tvg-id="tickerNews.au" tvg-chno="16" group-title="News",Ticker News


### PR DESCRIPTION
## zz_news_en
- **LiveNOW from FOX**: `lnc-fox-live-now.tubi.video` no longer resolves. Replaced with the Amagi-hosted feed already used for the same channel under `lists/usa.md`'s "FOX Live Now" entry. Verified alive via local checker (3/3 ok).

## Serbia
- **RTS 3**: the old udp-multicast-proxy URL (`185.81.240.65:15000`) is unreachable. Found the current feed on the same official bhtelecom.ba CDN already used for RTS 1 and RTS 2 in this file. Verified alive via local checker (3/3 ok), real HLS master playlist with two variants.

## Researched but left unchanged
- **zz_news_en**: The Guardian, CBC News Network, Sky News Now (AU), i24 News, CNBC Europe, CNBC Indonesia, Pluto TV News — official infrastructure down, geo/paywall-gated, or no public stream exists. CNN (line 36) wasn't touched — the only replacement found is the exact same feed already used by the "CNN International" row in this file, which would just duplicate an entry rather than fix a distinct one.
- **Moldova**: Publika TV group and Balti TV — official domains gone, no replacement found.
- **Serbia**: Euronews Serbia has a real working stream, but it requires a custom `Referer` header this repo's plain-URL playlist format can't carry — not usable as a drop-in fix. Red TV — no replacement found.
- **Slovakia**: every channel points at a domain (`sktv.mxnticek.eu`) that is completely down. Found working replacements for 3 channels via STVR's own JSON endpoint, but those URLs embed a short-lived signed token that expires — not usable as a static playlist entry (same reasoning as the Sweden Solidtango tokens rejected earlier). No durable fix currently available for this file.
- **Montenegro**: no dead channels found.
- **Bosnia and Herzegovina**: BHT 1's URL times out, but it's confirmed to be the exact URL BHRT's own official site uses internally — looks like a genuine infra/geo outage at the source, not a stale link, so left unchanged. No fix found for Federalna TV, TV BPK, Kanal 6, TNT Kids, Sevdah, RTV Glas Drine, TVSA, RTV TK.

Regenerated `playlist.m3u8` and the per-country playlists via `make_playlist.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enus8N247jHM5r5Som5JuU
