### PR TITLE
Fix dead SBS family, 9Now family, and C31 Melbourne links (Australia)

### DIFF
--- a/lists/australia.md
+++ b/lists/australia.md
@@ -6,7 +6,7 @@ https://www.freeview.com.au
 |:---:|:---------------:|:-----:|:----:|:------:|
 | 5   | 10 HD           | [>](https://i.mjh.nz/.r/10-nsw.m3u8) | <img height="20" src="https://i.imgur.com/ZjKvXPn.png"/> | 10Sydney.au |
 | 1   | ABC             | [>](https://c.mjh.nz/abc-nsw.m3u8) | <img height="20" src="https://i.imgur.com/5CVl5EF.png"/> | ABCTV.au |
-| 5   | SBS             | [x]() | <img height="20" src="https://i.imgur.com/GBl1ynA.png"/> | SBSTV.au |
+| 5   | SBS Ⓖ           | [>](https://i.mjh.nz/.r/sbs-sbst.m3u8) | <img height="20" src="https://i.imgur.com/GBl1ynA.png"/> | SBSTV.au |
 | 5   | Seven           | [>](https://i.mjh.nz/.r/seven-syd.m3u8) | <img height="20" src="https://i.imgur.com/6zwKJaa.png"/> | SevenNetwork.au |
 | 5   | Nine            | [>](https://i.mjh.nz/.r/channel-9-nsw.m3u8) | <img height="20" src="https://i.imgur.com/SMXwfr5.png"/> | NineNetwork.au |
 | 5   | 10 Peach        | [>](https://i.mjh.nz/.r/10peach-nsw.m3u8) | <img height="20" src="https://i.imgur.com/NlZLut8.png"/> | 10Peach.au |
@@ -18,16 +18,16 @@ https://www.freeview.com.au
 | 4   | ABC Me          | [>](https://c.mjh.nz/abc-me.m3u8) | <img height="20" src="https://i.imgur.com/gBh54wY.png"/> | ABCMe.au |
 | 5   | ABC News        | [>](https://c.mjh.nz/abc-news.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/thumb/d/df/ABC_News_Channel.svg/500px-ABC_News_Channel.svg.png"/> | ABCNews.au |
 | 8   | M4TV      | [>](https://5a32c05065c79.streamlock.net/live/stream/playlist.m3u8) | <img height="20" src="https://i.imgur.com/HZohlNk.png"/> | M4TV.au |
-| 5   | SBS Viceland    | [x]() | <img height="20" src="https://i.imgur.com/WMKCkD0.png"/> | SBSViceland.au |
-| 5   | SBS World Movies| [x]() | <img height="20" src="https://i.imgur.com/V6hhtCx.png"/> | SBSWorldMovies.au |
-| 5   | SBS Food        | [x]() | <img height="20" src="https://i.imgur.com/qN9p4h0.png"/> | SBSFood.au |
-| 5   | NITV            | [x]() | <img height="20" src="https://i.imgur.com/YR7sXaN.png"/> | NITV.au |
+| 5   | SBS Viceland Ⓖ  | [>](https://i.mjh.nz/.r/sbs-2syd.m3u8) | <img height="20" src="https://i.imgur.com/WMKCkD0.png"/> | SBSViceland.au |
+| 5   | SBS World Movies Ⓖ | [>](https://i.mjh.nz/.r/sbs-4syd.m3u8) | <img height="20" src="https://i.imgur.com/V6hhtCx.png"/> | SBSWorldMovies.au |
+| 5   | SBS Food Ⓖ      | [>](https://i.mjh.nz/.r/sbs-3syd.m3u8) | <img height="20" src="https://i.imgur.com/qN9p4h0.png"/> | SBSFood.au |
+| 5   | NITV Ⓖ          | [>](https://i.mjh.nz/.r/sbs-5nsw.m3u8) | <img height="20" src="https://i.imgur.com/YR7sXaN.png"/> | NITV.au |
 | 5   | 7two            | [>](https://i.mjh.nz/.r/7two-syd.m3u8) | <img height="20" src="https://i.imgur.com/6pyIg02.png"/> | 7two.au |
 | 5   | 7mate           | [>](https://i.mjh.nz/.r/7mate-syd.m3u8) | <img height="20" src="https://i.imgur.com/zpr12HP.png"/> | 7mate.au |
 | 5   | 7flix           | [>](https://i.mjh.nz/.r/7flix-syd.m3u8) | <img height="20" src="https://i.imgur.com/6iIYCyC.png"/> | 7flix.au |
 | 5   | Racing.com      | [>](https://racingvic-i.akamaized.net/hls/live/598695/racingvic/1500.m3u8) | <img height="20" src="https://i.imgur.com/pma0OCf.png"/> | Racingcom.au |
-| 5   | 9Gem Ⓖ          | [>](https://9now-livestreams.akamaized.net/hls/live/2008311/gem-syd/master.m3u8) | <img height="20" src="https://i.imgur.com/sWmE1kq.png"/> | 9Gem.au |
-| 5   | 9Go! Ⓖ | [>](https://9now-livestreams.akamaized.net/hls/live/2008312/go-syd/master.m3u8) | <img height="20" src="https://i.imgur.com/1CFGu5O.png"/> | 9Go.au |
-| 5   | 9Life Ⓖ | [>](https://9now-livestreams.akamaized.net/hls/live/2008313/life-syd/master.m3u8) | <img height="20" src="https://i.imgur.com/ZCUiqlL.png"/> | 9Life.au |
-| 5   | 9Rush Ⓖ | [>](https://9now-livestreams.akamaized.net/hls/live/2010626/rush-syd/master.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/c/c2/Logo_of_9RUSH.png"/> | 9Rush.au |
-| 5   | C31 Melbourne   | [x]() | <img height="20" src="https://i.imgur.com/dXwkFei.png"/> | C31Melbourne.au |
+| 5   | 9Gem Ⓖ          | [>](https://i.mjh.nz/.r/gem-nsw.m3u8) | <img height="20" src="https://i.imgur.com/sWmE1kq.png"/> | 9Gem.au |
+| 5   | 9Go! Ⓖ | [>](https://i.mjh.nz/.r/go-nsw.m3u8) | <img height="20" src="https://i.imgur.com/1CFGu5O.png"/> | 9Go.au |
+| 5   | 9Life Ⓖ | [>](https://i.mjh.nz/.r/life-nsw.m3u8) | <img height="20" src="https://i.imgur.com/ZCUiqlL.png"/> | 9Life.au |
+| 5   | 9Rush Ⓖ | [>](https://i.mjh.nz/.r/rush-nsw.m3u8) | <img height="20" src="https://upload.wikimedia.org/wikipedia/en/c/c2/Logo_of_9RUSH.png"/> | 9Rush.au |
+| 5   | C31 Melbourne   | [>](https://d1k6kax80wecy5.cloudfront.net/RLnAKY/index.m3u8) | <img height="20" src="https://i.imgur.com/dXwkFei.png"/> | C31Melbourne.au |

--- a/playlist.m3u8
+++ b/playlist.m3u8
@@ -97,6 +97,8 @@ http://stream.mcquack.net/175/index.m3u8
 https://i.mjh.nz/.r/10-nsw.m3u8
 #EXTINF:-1 tvg-name="ABC" tvg-logo="https://i.imgur.com/5CVl5EF.png" tvg-id="ABCTV.au" tvg-chno="1" tvg-country="AU" group-title="Australia",ABC
 https://c.mjh.nz/abc-nsw.m3u8
+#EXTINF:-1 tvg-name="SBS" tvg-logo="https://i.imgur.com/GBl1ynA.png" tvg-id="SBSTV.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS Ⓖ
+https://i.mjh.nz/.r/sbs-sbst.m3u8
 #EXTINF:-1 tvg-name="Seven" tvg-logo="https://i.imgur.com/6zwKJaa.png" tvg-id="SevenNetwork.au" tvg-chno="5" tvg-country="AU" group-title="Australia",Seven
 https://i.mjh.nz/.r/seven-syd.m3u8
 #EXTINF:-1 tvg-name="Nine" tvg-logo="https://i.imgur.com/SMXwfr5.png" tvg-id="NineNetwork.au" tvg-chno="5" tvg-country="AU" group-title="Australia",Nine
@@ -117,6 +119,14 @@ https://c.mjh.nz/abc-me.m3u8
 https://c.mjh.nz/abc-news.m3u8
 #EXTINF:-1 tvg-name="M4TV" tvg-logo="https://i.imgur.com/HZohlNk.png" tvg-id="M4TV.au" tvg-chno="8" tvg-country="AU" group-title="Australia",M4TV
 https://5a32c05065c79.streamlock.net/live/stream/playlist.m3u8
+#EXTINF:-1 tvg-name="SBS Viceland" tvg-logo="https://i.imgur.com/WMKCkD0.png" tvg-id="SBSViceland.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS Viceland Ⓖ
+https://i.mjh.nz/.r/sbs-2syd.m3u8
+#EXTINF:-1 tvg-name="SBS World Movies" tvg-logo="https://i.imgur.com/V6hhtCx.png" tvg-id="SBSWorldMovies.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS World Movies Ⓖ
+https://i.mjh.nz/.r/sbs-4syd.m3u8
+#EXTINF:-1 tvg-name="SBS Food" tvg-logo="https://i.imgur.com/qN9p4h0.png" tvg-id="SBSFood.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS Food Ⓖ
+https://i.mjh.nz/.r/sbs-3syd.m3u8
+#EXTINF:-1 tvg-name="NITV" tvg-logo="https://i.imgur.com/YR7sXaN.png" tvg-id="NITV.au" tvg-chno="5" tvg-country="AU" group-title="Australia",NITV Ⓖ
+https://i.mjh.nz/.r/sbs-5nsw.m3u8
 #EXTINF:-1 tvg-name="7two" tvg-logo="https://i.imgur.com/6pyIg02.png" tvg-id="7two.au" tvg-chno="5" tvg-country="AU" group-title="Australia",7two
 https://i.mjh.nz/.r/7two-syd.m3u8
 #EXTINF:-1 tvg-name="7mate" tvg-logo="https://i.imgur.com/zpr12HP.png" tvg-id="7mate.au" tvg-chno="5" tvg-country="AU" group-title="Australia",7mate
@@ -126,13 +136,15 @@ https://i.mjh.nz/.r/7flix-syd.m3u8
 #EXTINF:-1 tvg-name="Racing.com" tvg-logo="https://i.imgur.com/pma0OCf.png" tvg-id="Racingcom.au" tvg-chno="5" tvg-country="AU" group-title="Australia",Racing.com
 https://racingvic-i.akamaized.net/hls/live/598695/racingvic/1500.m3u8
 #EXTINF:-1 tvg-name="9Gem" tvg-logo="https://i.imgur.com/sWmE1kq.png" tvg-id="9Gem.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Gem Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2008311/gem-syd/master.m3u8
+https://i.mjh.nz/.r/gem-nsw.m3u8
 #EXTINF:-1 tvg-name="9Go!" tvg-logo="https://i.imgur.com/1CFGu5O.png" tvg-id="9Go.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Go! Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2008312/go-syd/master.m3u8
+https://i.mjh.nz/.r/go-nsw.m3u8
 #EXTINF:-1 tvg-name="9Life" tvg-logo="https://i.imgur.com/ZCUiqlL.png" tvg-id="9Life.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Life Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2008313/life-syd/master.m3u8
+https://i.mjh.nz/.r/life-nsw.m3u8
 #EXTINF:-1 tvg-name="9Rush" tvg-logo="https://upload.wikimedia.org/wikipedia/en/c/c2/Logo_of_9RUSH.png" tvg-id="9Rush.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Rush Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2010626/rush-syd/master.m3u8
+https://i.mjh.nz/.r/rush-nsw.m3u8
+#EXTINF:-1 tvg-name="C31 Melbourne" tvg-logo="https://i.imgur.com/dXwkFei.png" tvg-id="C31Melbourne.au" tvg-chno="5" tvg-country="AU" group-title="Australia",C31 Melbourne
+https://d1k6kax80wecy5.cloudfront.net/RLnAKY/index.m3u8
 #EXTINF:-1 tvg-name="ORF 1" tvg-logo="https://i.imgur.com/ft2LuRl.jpg" tvg-id="ORF1.at" tvg-chno="1" tvg-country="AT" group-title="Austria",ORF 1 Ⓖ
 https://orf1.mdn.ors.at/out/u/orf1/q8c/manifest.m3u8
 #EXTINF:-1 tvg-name="ORF 2" tvg-logo="https://i.imgur.com/yPVDaXv.png" tvg-id="ORF2.at" tvg-chno="2" tvg-country="AT" group-title="Austria",ORF 2 Ⓖ

--- a/playlists/playlist_australia.m3u8
+++ b/playlists/playlist_australia.m3u8
@@ -3,6 +3,8 @@
 https://i.mjh.nz/.r/10-nsw.m3u8
 #EXTINF:-1 tvg-name="ABC" tvg-logo="https://i.imgur.com/5CVl5EF.png" tvg-id="ABCTV.au" tvg-chno="1" tvg-country="AU" group-title="Australia",ABC
 https://c.mjh.nz/abc-nsw.m3u8
+#EXTINF:-1 tvg-name="SBS" tvg-logo="https://i.imgur.com/GBl1ynA.png" tvg-id="SBSTV.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS Ⓖ
+https://i.mjh.nz/.r/sbs-sbst.m3u8
 #EXTINF:-1 tvg-name="Seven" tvg-logo="https://i.imgur.com/6zwKJaa.png" tvg-id="SevenNetwork.au" tvg-chno="5" tvg-country="AU" group-title="Australia",Seven
 https://i.mjh.nz/.r/seven-syd.m3u8
 #EXTINF:-1 tvg-name="Nine" tvg-logo="https://i.imgur.com/SMXwfr5.png" tvg-id="NineNetwork.au" tvg-chno="5" tvg-country="AU" group-title="Australia",Nine
@@ -23,6 +25,14 @@ https://c.mjh.nz/abc-me.m3u8
 https://c.mjh.nz/abc-news.m3u8
 #EXTINF:-1 tvg-name="M4TV" tvg-logo="https://i.imgur.com/HZohlNk.png" tvg-id="M4TV.au" tvg-chno="8" tvg-country="AU" group-title="Australia",M4TV
 https://5a32c05065c79.streamlock.net/live/stream/playlist.m3u8
+#EXTINF:-1 tvg-name="SBS Viceland" tvg-logo="https://i.imgur.com/WMKCkD0.png" tvg-id="SBSViceland.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS Viceland Ⓖ
+https://i.mjh.nz/.r/sbs-2syd.m3u8
+#EXTINF:-1 tvg-name="SBS World Movies" tvg-logo="https://i.imgur.com/V6hhtCx.png" tvg-id="SBSWorldMovies.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS World Movies Ⓖ
+https://i.mjh.nz/.r/sbs-4syd.m3u8
+#EXTINF:-1 tvg-name="SBS Food" tvg-logo="https://i.imgur.com/qN9p4h0.png" tvg-id="SBSFood.au" tvg-chno="5" tvg-country="AU" group-title="Australia",SBS Food Ⓖ
+https://i.mjh.nz/.r/sbs-3syd.m3u8
+#EXTINF:-1 tvg-name="NITV" tvg-logo="https://i.imgur.com/YR7sXaN.png" tvg-id="NITV.au" tvg-chno="5" tvg-country="AU" group-title="Australia",NITV Ⓖ
+https://i.mjh.nz/.r/sbs-5nsw.m3u8
 #EXTINF:-1 tvg-name="7two" tvg-logo="https://i.imgur.com/6pyIg02.png" tvg-id="7two.au" tvg-chno="5" tvg-country="AU" group-title="Australia",7two
 https://i.mjh.nz/.r/7two-syd.m3u8
 #EXTINF:-1 tvg-name="7mate" tvg-logo="https://i.imgur.com/zpr12HP.png" tvg-id="7mate.au" tvg-chno="5" tvg-country="AU" group-title="Australia",7mate
@@ -32,10 +42,12 @@ https://i.mjh.nz/.r/7flix-syd.m3u8
 #EXTINF:-1 tvg-name="Racing.com" tvg-logo="https://i.imgur.com/pma0OCf.png" tvg-id="Racingcom.au" tvg-chno="5" tvg-country="AU" group-title="Australia",Racing.com
 https://racingvic-i.akamaized.net/hls/live/598695/racingvic/1500.m3u8
 #EXTINF:-1 tvg-name="9Gem" tvg-logo="https://i.imgur.com/sWmE1kq.png" tvg-id="9Gem.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Gem Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2008311/gem-syd/master.m3u8
+https://i.mjh.nz/.r/gem-nsw.m3u8
 #EXTINF:-1 tvg-name="9Go!" tvg-logo="https://i.imgur.com/1CFGu5O.png" tvg-id="9Go.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Go! Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2008312/go-syd/master.m3u8
+https://i.mjh.nz/.r/go-nsw.m3u8
 #EXTINF:-1 tvg-name="9Life" tvg-logo="https://i.imgur.com/ZCUiqlL.png" tvg-id="9Life.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Life Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2008313/life-syd/master.m3u8
+https://i.mjh.nz/.r/life-nsw.m3u8
 #EXTINF:-1 tvg-name="9Rush" tvg-logo="https://upload.wikimedia.org/wikipedia/en/c/c2/Logo_of_9RUSH.png" tvg-id="9Rush.au" tvg-chno="5" tvg-country="AU" group-title="Australia",9Rush Ⓖ
-https://9now-livestreams.akamaized.net/hls/live/2010626/rush-syd/master.m3u8
+https://i.mjh.nz/.r/rush-nsw.m3u8
+#EXTINF:-1 tvg-name="C31 Melbourne" tvg-logo="https://i.imgur.com/dXwkFei.png" tvg-id="C31Melbourne.au" tvg-chno="5" tvg-country="AU" group-title="Australia",C31 Melbourne
+https://d1k6kax80wecy5.cloudfront.net/RLnAKY/index.m3u8


### PR DESCRIPTION
- **SBS, SBS Viceland, SBS World Movies, SBS Food, NITV**: had no URL at all. Found the correct current channel keys behind the `i.mjh.nz` redirector already used successfully by other entries in this file (Seven, Nine, 7two, etc). The redirector mints a fresh token and forwards to SBS's real Akamai edge, which explicitly declines non-Australian requests (`X-Error-Reason: geo-blocked`) — real, correctly-functioning access control, not a broken link — so marked Ⓖ like the file's other geo-blocked entries (9Gem, 9Go!, etc).
- **9Gem, 9Go!, 9Life, 9Rush**: the old direct `9now-livestreams.akamaized.net` URLs now 400 (stale signed paths). Replaced with the same `i.mjh.nz` redirector mechanism, which mints a fresh token per request instead of embedding a static one. Verified alive via local checker (3/3 ok), real HLS master + variant playlists.
- **C31 Melbourne**: had no URL. The station now operates under the CTV Plus community-TV platform after a 2016 licensing change; found its current CloudFront-backed stream via ctvplus.org.au. Verified alive via local checker (3/3 ok), real HLS content with live segments.

## Researched but left unchanged
- **Spree TV, M4TV**: official domains parked or unresolvable, stations appear defunct.
- **10 Shake, Racing.com**: newly found dead (stale CDN paths), but their official platforms are JS SPAs with no static stream discoverable.

Regenerated `playlist.m3u8` and `playlists/playlist_australia.m3u8` via `make_playlist.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enus8N247jHM5r5Som5JuU
